### PR TITLE
Sync resources.json with that in gem5/gem5-resources

### DIFF
--- a/public/resources.json
+++ b/public/resources.json
@@ -9,6 +9,201 @@
     },
     "resources": [
         {
+            "type": "workload",
+            "name": "x86-matrix-multiply-omp-100-8-looppoint-csv",
+            "documentation": "A workload used to load the Looppoint pinpoint CSV file for the 'x86-matrix-multiply-omp' resource with the arguments '100' and '8'. This is used in the 'configs/example/gem5_library/looppoints/create-looppoint-checkpoints.py' to demonstrate generating Checkpoints for Looppoint regions.",
+            "function": "set_se_looppoint_workload",
+            "resources" : {
+                "binary" : "x86-matrix-multiply-omp",
+                "looppoint" : "x86-matrix-multiply-omp-100-8-global-pinpoints"
+            },
+            "additional_params" : {
+                "arguments" : [100, 8]
+            }
+        },
+        {
+            "type": "workload",
+            "name": "x86-matrix-multiply-omp-100-8-looppoint-region-1",
+            "documentation": "A workload which loads a Looppoint JSON file for the 'x86-matrix-multiply-omp' binary with inputs '100' and '8' and runs region 1 via a checkpoint.",
+            "function": "set_se_looppoint_workload",
+            "resources": {
+                "binary": "x86-matrix-multiply-omp",
+                "looppoint": "x86-matrix-multiply-omp-100-8-looppoint",
+                "checkpoint": "x86-matrix-multiply-omp-100-8-looppoint-checkpoint-region-1"
+            },
+            "additional_params": {
+                "region_id": "1"
+            }
+        },
+        {
+            "type": "workload",
+            "name": "x86-matrix-multiply-omp-100-8-looppoint-region-2",
+            "documentation": "A workload which loads a Looppoint JSON file for the 'x86-matrix-multiply-omp' binary with inputs '100' and '8' and runs region 2 via a checkpoint.",
+            "function": "set_se_looppoint_workload",
+            "resources": {
+                "binary": "x86-matrix-multiply-omp",
+                "looppoint": "x86-matrix-multiply-omp-100-8-looppoint",
+                "checkpoint": "x86-matrix-multiply-omp-100-8-looppoint-checkpoint-region-2"
+            },
+            "additional_params": {
+                "region_id": "2"
+            }
+        },
+        {
+            "type": "workload",
+            "name": "x86-matrix-multiply-omp-100-8-looppoint-region-3",
+            "documentation": "A workload which loads a Looppoint JSON file for the 'x86-matrix-multiply-omp' binary with inputs '100' and '8' and runs region 3 via a checkpoint.",
+            "function": "set_se_looppoint_workload",
+            "resources": {
+                "binary": "x86-matrix-multiply-omp",
+                "looppoint": "x86-matrix-multiply-omp-100-8-looppoint",
+                "checkpoint": "x86-matrix-multiply-omp-100-8-looppoint-checkpoint-region-3"
+            },
+            "additional_params": {
+                "region_id": "3"
+            }
+        },
+        {
+            "type": "workload",
+            "name": "x86-matrix-multiply-omp-100-8-looppoint-region-5",
+            "documentation": "A workload which loads a Looppoint JSON file for the 'x86-matrix-multiply-omp' binary with inputs '100' and '8' and runs region 5 via a checkpoint.",
+            "function": "set_se_looppoint_workload",
+            "resources": {
+                "binary": "x86-matrix-multiply-omp",
+                "looppoint": "x86-matrix-multiply-omp-100-8-looppoint",
+                "checkpoint": "x86-matrix-multiply-omp-100-8-looppoint-checkpoint-region-5"
+            },
+            "additional_params": {
+                "region_id": "5"
+            }
+        },
+        {
+            "type": "workload",
+            "name": "x86-matrix-multiply-omp-100-8-looppoint-region-6",
+            "documentation": "A workload which loads a Looppoint JSON file for the 'x86-matrix-multiply-omp' binary with inputs '100' and '8' and runs region 6 via a checkpoint.",
+            "function": "set_se_looppoint_workload",
+            "resources": {
+                "binary": "x86-matrix-multiply-omp",
+                "looppoint": "x86-matrix-multiply-omp-100-8-looppoint",
+                "checkpoint": "x86-matrix-multiply-omp-100-8-looppoint-checkpoint-region-6"
+            },
+            "additional_params": {
+                "region_id": "6"
+            }
+        },
+        {
+            "type": "workload",
+            "name": "x86-matrix-multiply-omp-100-8-looppoint-region-7",
+            "documentation": "A workload which loads a Looppoint JSON file for the 'x86-matrix-multiply-omp' binary with inputs '100' and '8' and runs region 7 via a checkpoint.",
+            "function": "set_se_looppoint_workload",
+            "resources": {
+                "binary": "x86-matrix-multiply-omp",
+                "looppoint": "x86-matrix-multiply-omp-100-8-looppoint",
+                "checkpoint": "x86-matrix-multiply-omp-100-8-looppoint-checkpoint-region-7"
+            },
+            "additional_params": {
+                "region_id": "7"
+            }
+        },
+        {
+            "type": "workload",
+            "name": "x86-matrix-multiply-omp-100-8-looppoint-region-8",
+            "documentation": "A workload which loads a Looppoint JSON file for the 'x86-matrix-multiply-omp' binary with inputs '100' and '8' and runs region 8 via a checkpoint.",
+            "function": "set_se_looppoint_workload",
+            "resources": {
+                "binary": "x86-matrix-multiply-omp",
+                "looppoint": "x86-matrix-multiply-omp-100-8-looppoint",
+                "checkpoint": "x86-matrix-multiply-omp-100-8-looppoint-checkpoint-region-8"
+            },
+            "additional_params": {
+                "region_id": "8"
+            }
+        },
+        {
+            "type": "workload",
+            "name": "x86-matrix-multiply-omp-100-8-looppoint-region-9",
+            "documentation": "A workload which loads a Looppoint JSON file for the 'x86-matrix-multiply-omp' binary with inputs '100' and '8' and runs region 9 via a checkpoint.",
+            "function": "set_se_looppoint_workload",
+            "resources": {
+                "binary": "x86-matrix-multiply-omp",
+                "looppoint": "x86-matrix-multiply-omp-100-8-looppoint",
+                "checkpoint": "x86-matrix-multiply-omp-100-8-looppoint-checkpoint-region-9"
+            },
+            "additional_params": {
+                "region_id": "9"
+            }
+        },
+        {
+            "type": "workload",
+            "name": "x86-matrix-multiply-omp-100-8-looppoint-region-10",
+            "documentation": "A workload which loads a Looppoint JSON file for the 'x86-matrix-multiply-omp' binary with inputs '100' and '8' and runs region 10 via a checkpoint.",
+            "function": "set_se_looppoint_workload",
+            "resources": {
+                "binary": "x86-matrix-multiply-omp",
+                "looppoint": "x86-matrix-multiply-omp-100-8-looppoint",
+                "checkpoint": "x86-matrix-multiply-omp-100-8-looppoint-checkpoint-region-10"
+            },
+            "additional_params": {
+                "region_id": "10"
+            }
+        },
+       {
+            "type": "workload",
+            "name": "x86-matrix-multiply-omp-100-8-looppoint-region-11",
+            "documentation": "A workload which loads a Looppoint JSON file for the 'x86-matrix-multiply-omp' binary with inputs '100' and '8' and runs region 11 via a checkpoint.",
+            "function": "set_se_looppoint_workload",
+            "resources": {
+                "binary": "x86-matrix-multiply-omp",
+                "looppoint": "x86-matrix-multiply-omp-100-8-looppoint",
+                "checkpoint": "x86-matrix-multiply-omp-100-8-looppoint-checkpoint-region-11"
+            },
+            "additional_params": {
+                "region_id": "11"
+            }
+        },
+        {
+            "type": "workload",
+            "name": "x86-matrix-multiply-omp-100-8-looppoint-region-12",
+            "documentation": "A workload which loads a Looppoint JSON file for the 'x86-matrix-multiply-omp' binary with inputs '100' and '8' and runs region 12 via a checkpoint.",
+            "function": "set_se_looppoint_workload",
+            "resources": {
+                "binary": "x86-matrix-multiply-omp",
+                "looppoint": "x86-matrix-multiply-omp-100-8-looppoint",
+                "checkpoint": "x86-matrix-multiply-omp-100-8-looppoint-checkpoint-region-12"
+            },
+            "additional_params": {
+                "region_id": "12"
+            }
+        },
+        {
+            "type": "workload",
+            "name": "x86-matrix-multiply-omp-100-8-looppoint-region-13",
+            "documentation": "A workload which loads a Looppoint JSON file for the 'x86-matrix-multiply-omp' binary with inputs '100' and '8' and runs region 13 via a checkpoint.",
+            "function": "set_se_looppoint_workload",
+            "resources": {
+                "binary": "x86-matrix-multiply-omp",
+                "looppoint": "x86-matrix-multiply-omp-100-8-looppoint",
+                "checkpoint": "x86-matrix-multiply-omp-100-8-looppoint-checkpoint-region-13"
+            },
+            "additional_params": {
+                "region_id": "13"
+            }
+        },
+        {
+            "type": "workload",
+            "name": "x86-matrix-multiply-omp-100-8-looppoint-region-14",
+            "documentation": "A workload which loads a Looppoint JSON file for the 'x86-matrix-multiply-omp' binary with inputs '100' and '8' and runs region 14 via a checkpoint.",
+            "function": "set_se_looppoint_workload",
+            "resources": {
+                "binary": "x86-matrix-multiply-omp",
+                "looppoint": "x86-matrix-multiply-omp-100-8-looppoint",
+                "checkpoint": "x86-matrix-multiply-omp-100-8-looppoint-checkpoint-region-14"
+            },
+            "additional_params": {
+                "region_id": "14"
+            }
+        },
+        {
             "type" : "workload",
             "name" : "x86-ubuntu-18.04-boot",
             "documentation" : "A full boot of Ubuntu 18.04 with Linux 5.4.49 for X86. It runs an `m5 exit` command when the boot is completed unless the readfile is specified. If specified the readfile will be executed after booting.",
@@ -85,6 +280,17 @@
             }
         },
         {
+            "type": "binary",
+            "name": "x86-gpu-square",
+            "documentation": "A simple GPU kernel which squares a vector.",
+            "architecture": "X86",
+            "is_zipped" : false,
+            "md5sum" : "54dde4b5199ab2808dd3e90cf33f66bf",
+            "source" : "src/gpu/square",
+            "is_tar_archive" : false,
+            "url": "{url_base}/test-progs/square/square"
+        },
+        {
             "type": "resource",
             "name" : "vega-mmio",
             "documentation" : "Used with the 'x86-gpu-fs-img' disk image.",
@@ -129,6 +335,171 @@
         },
         {
             "type": "resource",
+            "name" : "simpoints-se-checkpoints-v23-0-v1",
+            "documentation" : "The checkpoint used in 'configs/example/gem5_library/checkpoints/simpoints-se-restore.py'.",
+            "architecture": "X86",
+            "is_zipped" : true,
+            "md5sum" : "8b4772fa3d652d03b6d21fd172846810",
+            "source" : null,
+            "is_tar_archive" : true,
+            "url": "{url_base}/checkpoints/simpoints-se-checkpoint-example-20230222.tar.gz"
+        },
+
+        {
+            "type": "resource",
+            "name" : "x86-matrix-multiply-omp-100-8-looppoint-checkpoint-region-1",
+            "documentation" : "The region 1 looppoint checkpoint for the 'matrix-multiple-omp' resource with '100' and '8' as input parameters. Created with the 'configs/example/gem5_library/looppoints/create-looppoint-checkpoints.py' script",
+            "architecture": "X86",
+            "is_zipped" : true,
+            "md5sum" : "7e80e3b7696d3792742662c0d5ddca9c",
+            "source" : null,
+            "is_tar_archive" : true,
+            "url": "{url_base}/checkpoints/x86-matrix-multiply-omp-100-8/x86-matrix-multiply-omp-100-8-looppoint-checkpoint-region-1.tar.gz"
+        },
+        {
+            "type": "resource",
+            "name" : "x86-matrix-multiply-omp-100-8-looppoint-checkpoint-region-2",
+            "documentation" : "The region 2 looppoint checkpoint for the 'matrix-multiple-omp' resource with '100' and '8' as input parameters. Created with the 'configs/example/gem5_library/looppoints/create-looppoint-checkpoints.py' script",
+            "architecture": "X86",
+            "is_zipped" : true,
+            "md5sum" : "210cc487488534c927af5af7006f9810",
+            "source" : null,
+            "is_tar_archive" : true,
+            "url": "{url_base}/checkpoints/x86-matrix-multiply-omp-100-8/x86-matrix-multiply-omp-100-8-looppoint-checkpoint-region-2.tar.gz"
+        },
+        {
+            "type": "resource",
+            "name" : "x86-matrix-multiply-omp-100-8-looppoint-checkpoint-region-3",
+            "documentation" : "The region 3 looppoint checkpoint for the 'matrix-multiple-omp' resource with '100' and '8' as input parameters. Created with the 'configs/example/gem5_library/looppoints/create-looppoint-checkpoints.py' script",
+            "architecture": "X86",
+            "is_zipped" : true,
+            "md5sum" : "6db3dcada4145802a0afb44a29698d5f",
+            "source" : null,
+            "is_tar_archive" : true,
+            "url": "{url_base}/checkpoints/x86-matrix-multiply-omp-100-8/x86-matrix-multiply-omp-100-8-looppoint-checkpoint-region-3.tar.gz"
+        },
+        {
+            "type": "resource",
+            "name" : "x86-matrix-multiply-omp-100-8-looppoint-checkpoint-region-5",
+            "documentation" : "The region 5 looppoint checkpoint for the 'matrix-multiple-omp' resource with '100' and '8' as input parameters. Created with the 'configs/example/gem5_library/looppoints/create-looppoint-checkpoints.py' script",
+            "architecture": "X86",
+            "is_zipped" : true,
+            "md5sum" : "d70cdfa1430467de2ddf78c11899f834",
+            "source" : null,
+            "is_tar_archive" : true,
+            "url": "{url_base}/checkpoints/x86-matrix-multiply-omp-100-8/x86-matrix-multiply-omp-100-8-looppoint-checkpoint-region-5.tar.gz"
+        },
+        {
+            "type": "resource",
+            "name" : "x86-matrix-multiply-omp-100-8-looppoint-checkpoint-region-6",
+            "documentation" : "The region 6 looppoint checkpoint for the 'matrix-multiple-omp' resource with '100' and '8' as input parameters. Created with the 'configs/example/gem5_library/looppoints/create-looppoint-checkpoints.py' script",
+            "is_zipped" : true,
+            "md5sum" : "5feddce6160101b35cc53c0d37684f3a",
+            "source" : null,
+            "is_tar_archive" : true,
+            "url": "{url_base}/checkpoints/x86-matrix-multiply-omp-100-8/x86-matrix-multiply-omp-100-8-looppoint-checkpoint-region-6.tar.gz"
+        },
+        {
+            "type": "resource",
+            "name" : "x86-matrix-multiply-omp-100-8-looppoint-checkpoint-region-7",
+            "documentation" : "The region 7 looppoint checkpoint for the 'matrix-multiple-omp' resource with '100' and '8' as input parameters. Created with the 'configs/example/gem5_library/looppoints/create-looppoint-checkpoints.py' script",
+            "architecture": "X86",
+            "is_zipped" : true,
+            "md5sum" : "bf47198a9fa2f8397f0af7b78ffe2f0e",
+            "source" : null,
+            "is_tar_archive" : true,
+            "url": "{url_base}/checkpoints/x86-matrix-multiply-omp-100-8/x86-matrix-multiply-omp-100-8-looppoint-checkpoint-region-7.tar.gz"
+        },
+        {
+            "type": "resource",
+            "name" : "x86-matrix-multiply-omp-100-8-looppoint-checkpoint-region-8",
+            "documentation" : "The region 8 looppoint checkpoint for the 'matrix-multiple-omp' resource with '100' and '8' as input parameters. Created with the 'configs/example/gem5_library/looppoints/create-looppoint-checkpoints.py' script",
+            "architecture": "X86",
+            "is_zipped" : true,
+            "md5sum" : "b1de0501033a44636b2a882dc445c598",
+            "source" : null,
+            "is_tar_archive" : true,
+            "url": "{url_base}/checkpoints/x86-matrix-multiply-omp-100-8/x86-matrix-multiply-omp-100-8-looppoint-checkpoint-region-8.tar.gz"
+        },
+        {
+            "type": "resource",
+            "name" : "x86-matrix-multiply-omp-100-8-looppoint-checkpoint-region-9",
+            "documentation" : "The region 9 looppoint checkpoint for the 'matrix-multiple-omp' resource with '100' and '8' as input parameters. Created with the 'configs/example/gem5_library/looppoints/create-looppoint-checkpoints.py' script",
+            "architecture": "X86",
+            "is_zipped" : true,
+            "md5sum" : "5d23be3e3ab4d654601567e0400b4639",
+            "source" : null,
+            "is_tar_archive" : true,
+            "url": "{url_base}/checkpoints/x86-matrix-multiply-omp-100-8/x86-matrix-multiply-omp-100-8-looppoint-checkpoint-region-9.tar.gz"
+        },
+        {
+            "type": "resource",
+            "name" : "x86-matrix-multiply-omp-100-8-looppoint-checkpoint-region-10",
+            "documentation" : "The region 10 looppoint checkpoint for the 'matrix-multiple-omp' resource with '100' and '8' as input parameters. Created with the 'configs/example/gem5_library/looppoints/create-looppoint-checkpoints.py' script",
+            "architecture": "X86",
+            "is_zipped" : true,
+            "md5sum" : "4a5ed7c339f084c308d2c21f15bdcbd3",
+            "source" : null,
+            "is_tar_archive" : true,
+            "url": "{url_base}/checkpoints/x86-matrix-multiply-omp-100-8/x86-matrix-multiply-omp-100-8-looppoint-checkpoint-region-10.tar.gz"
+        },
+        {
+            "type": "resource",
+            "name" : "x86-matrix-multiply-omp-100-8-looppoint-checkpoint-region-11",
+            "documentation" : "The region 11 looppoint checkpoint for the 'matrix-multiple-omp' resource with '100' and '8' as input parameters. Created with the 'configs/example/gem5_library/looppoints/create-looppoint-checkpoints.py' script",
+            "architecture": "X86",
+            "is_zipped" : true,
+            "md5sum" : "5452d3d65d71e6f42c1ec9f40aef1e75",
+            "source" : null,
+            "is_tar_archive" : true,
+            "url": "{url_base}/checkpoints/x86-matrix-multiply-omp-100-8/x86-matrix-multiply-omp-100-8-looppoint-checkpoint-region-11.tar.gz"
+        },
+        {
+            "type": "resource",
+            "name" : "x86-matrix-multiply-omp-100-8-looppoint-checkpoint-region-12",
+            "documentation" : "The region 12 looppoint checkpoint for the 'matrix-multiple-omp' resource with '100' and '8' as input parameters. Created with the 'configs/example/gem5_library/looppoints/create-looppoint-checkpoints.py' script",
+            "architecture": "X86",
+            "is_zipped" : true,
+            "md5sum" : "2ee4e1dc827ec5eb05eaba6707c2f166",
+            "source" : null,
+            "is_tar_archive" : true,
+            "url": "{url_base}/checkpoints/x86-matrix-multiply-omp-100-8/x86-matrix-multiply-omp-100-8-looppoint-checkpoint-region-12.tar.gz"
+        },
+        {
+            "type": "resource",
+            "name" : "x86-matrix-multiply-omp-100-8-looppoint-checkpoint-region-13",
+            "documentation" : "The region 13 looppoint checkpoint for the 'matrix-multiple-omp' resource with '100' and '8' as input parameters. Created with the 'configs/example/gem5_library/looppoints/create-looppoint-checkpoints.py' script",
+            "architecture": "X86",
+            "is_zipped" : true,
+            "md5sum" : "0c1b15aa47df70f65c52b25f1b0b3a80",
+            "source" : null,
+            "is_tar_archive" : true,
+            "url": "{url_base}/checkpoints/x86-matrix-multiply-omp-100-8/x86-matrix-multiply-omp-100-8-looppoint-checkpoint-region-13.tar.gz"
+        },
+        {
+            "type": "resource",
+            "name" : "x86-matrix-multiply-omp-100-8-looppoint-checkpoint-region-14",
+            "documentation" : "The region 14 looppoint checkpoint for the 'matrix-multiple-omp' resource with '100' and '8' as input parameters. Created with the 'configs/example/gem5_library/looppoints/create-looppoint-checkpoints.py' script",
+            "architecture": "X86",
+            "is_zipped" : true,
+            "md5sum" : "88c91436f55e0c000a7d8b2b4afdb5a4",
+            "source" : null,
+            "is_tar_archive" : true,
+            "url": "{url_base}/checkpoints/x86-matrix-multiply-omp-100-8/x86-matrix-multiply-omp-100-8-looppoint-checkpoint-region-14.tar.gz"
+        },
+        {
+            "type": "looppoint-json",
+            "name" : "x86-matrix-multiply-omp-100-8-looppoint",
+            "documentation" : "The looppoint JSON file for the 'x86-matrix-multiply-omp' binary resource with input parameters '100' and '8'.",
+            "architecture": "X86",
+            "is_zipped" : false,
+            "md5sum" : "efb85ebdf90c5cee655bf2e05ae7692a",
+            "source" : null,
+            "is_tar_archive" : false,
+            "url": "{url_base}/looppoints/x86-matrix-multiply-omp-100-8-looppoint-json-20230128"
+        },
+        {
+            "type": "resource",
             "name" : "riscv-hello-example-checkpoint-v22-1",
             "documentation" : "A checkpoint used in 'configs/example/gem5_library/checkpoints/riscv-hello-restore-checkpoint.py'. Used for v22.1 onwards.",
             "architecture": "RISCV",
@@ -137,6 +508,17 @@
             "source" : null,
             "is_tar_archive" : true,
             "url": "{url_base}/checkpoints/riscv-hello-example-checkpoint-20220801.tar"
+        },
+        {
+            "type": "resource",
+            "name" : "riscv-hello-example-checkpoint-v23",
+            "documentation" : "A checkpoint used in 'configs/example/gem5_library/checkpoints/riscv-hello-restore-checkpoint.py'. Used for v22.1.1 onwards.",
+            "architecture": "RISCV",
+            "is_zipped" : false,
+            "md5sum" : "5c6e787965cecc4ebbee0119886f358c",
+            "source" : null,
+            "is_tar_archive" : true,
+            "url": "{url_base}/checkpoints/riscv-hello-example-checkpoint-20230222.tar"
         },
         {
             "type": "resource",
@@ -196,6 +578,26 @@
             "source" : "src/matrix-multiply"
         },
         {
+            "type" : "looppoint-pinpoint-csv",
+            "name" : "x86-matrix-multiply-omp-100-8-global-pinpoints",
+            "documentation" : "The Simpoint pinpoints file for the 'x86-matrix-multiply-omp' binary when running with the inputs '100' (iterations) and '8' (threads).",
+            "architecture" : "X86",
+            "is_zipped" : false,
+            "md5sum" : "199ab22dd463dc70ee2d034bfe045082",
+            "url" : "{url_base}/pinpoints/x86-matrix-multiply-omp-100-8-global-pinpoints-20230127",
+            "source" : null
+        },
+        {
+            "type" : "resource",
+            "name" : "x86-matrix-multiply-omp",
+            "documentation" : "A binary which runs a matrix mutiply operation on two 300x300 matrixes followed by a multiplication of two 150x150 matrices. These two matrix opperations are iterated over by an amount specified by the user via the first parameter. This binary utilizes OpenMP to parallelize the matrix operation. The number of threads used is specified by the user via the second parameter.",
+            "architecture" : "X86",
+            "is_zipped" : false,
+            "md5sum" : "922c9d005fdd22ca0fc3e501cc3eda58",
+            "url" : "{url_base}/test-progs/matrix-multiply-omp/x86-matrix-multiply-omp-20230127",
+            "source" : "src/matrix-multiply-omp"
+        },
+        {
             "type" : "resource",
             "name" : "x86-parsec",
             "documentation" : "A disk image containing the PARSEC benchmark suite, compiled to X86, built on top of Ubuntu 18.04.",
@@ -216,7 +618,7 @@
             "is_zipped" : true,
             "md5sum" : "c9217a88eff20e5547be87368a1499c1",
             "url" : "{url_base}/images/x86/ubuntu-18-04/gapbs.img.gz",
-            "source" : "src/gabps",
+            "source" : "src/gapbs",
             "additional_metadata" : {
                 "root_partition": "1"
             }
@@ -654,11 +1056,3971 @@
             "contents" : [
                 {
                     "type" : "resource",
+                    "name" : "rv32mi-p-breakpoint",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "f5a2fa83c0dd85dc63c1f97ad358a7de",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32mi-p-breakpoint",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32mi-p-csr",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "86254967b83a6253ae8602f36437239a",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32mi-p-csr",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32mi-p-illegal",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "c30867d77f2752f30f233f8012374e2a",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32mi-p-illegal",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32mi-p-ma_addr",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "5ef1c8693a62cadfe96fd35a6dc9d183",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32mi-p-ma_addr",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32mi-p-ma_fetch",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "a1ac08121d9ad6ab58186c45c2a43e37",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32mi-p-ma_fetch",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32mi-p-mcsr",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "818688682c564e04dd5e35d1498243a2",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32mi-p-mcsr",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32mi-p-sbreak",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "43ed6b37a4e46e3ea3a70dac5ae0e505",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32mi-p-sbreak",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32mi-p-scall",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "13da7e63da51a659a5fea318e50edef8",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32mi-p-scall",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32mi-p-shamt",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "7106a850fa9114fdb2a7fdc109fdc64b",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32mi-p-shamt",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32samt-ps-sysclone_w",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "e96731618968defa3f3d3ab8198a7ddf",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32samt-ps-sysclone_w",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32samt-ps-sysfutex1_w",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "005d4a93cecf9ff1b7e8d136a405760d",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32samt-ps-sysfutex1_w",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32samt-ps-sysfutex2_w",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "d5bb8c790a6ccb6f416f920b45232576",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32samt-ps-sysfutex2_w",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32samt-ps-sysfutex3_w",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "ec41f36abd695b003fc35380f9966336",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32samt-ps-sysfutex3_w",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32samt-ps-sysfutex_w",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "194e61378dc6f818ad5cf5f922f7f324",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32samt-ps-sysfutex_w",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32si-p-csr",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "e21ab00e10a5b917f318f2123b1a9b7c",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32si-p-csr",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32si-p-dirty",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "74e9120f2f1f527742c15e3e46e40a16",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32si-p-dirty",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32si-p-ma_fetch",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "76e0498002d2db28e4970d2c122b4650",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32si-p-ma_fetch",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32si-p-sbreak",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "78cd51445dec612801d9e8f71c459018",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32si-p-sbreak",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32si-p-scall",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "d0b4fad979ca872817c4e9a895ecc71f",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32si-p-scall",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32si-p-wfi",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "b9d2e4dc36a29390aecfa7b0b9bec017",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32si-p-wfi",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32uamt-ps-amoadd_w",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "87fa6e2b40e5762b6f8765f66f880055",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32uamt-ps-amoadd_w",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32uamt-ps-amoand_w",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "4a6a336b17e827234f77e4af2019d17e",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32uamt-ps-amoand_w",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32uamt-ps-amomaxu_w",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "75d215dbd7f011f3b078af5f5b8f02bd",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32uamt-ps-amomaxu_w",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32uamt-ps-amomax_w",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "bebc5cb32038cf918229b063cbbcdd9a",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32uamt-ps-amomax_w",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32uamt-ps-amominu_w",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "92779a8df70e08343337ccb3ba3dd061",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32uamt-ps-amominu_w",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32uamt-ps-amomin_w",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "8c9225e9b4a3f380b0679ca7a7d9c89c",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32uamt-ps-amomin_w",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32uamt-ps-amoor_w",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "99ca6f7f76c879e4439d42fbd4976612",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32uamt-ps-amoor_w",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32uamt-ps-amoswap_w",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "9f521deea61b9b56134f27145bf08bf8",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32uamt-ps-amoswap_w",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32uamt-ps-amoxor_w",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "48898b2045252e22badec7a5c74e9d9e",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32uamt-ps-amoxor_w",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32uamt-ps-lrsc_w",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "9ad4e065fd16d564e35eea0b56007ea1",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32uamt-ps-lrsc_w",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ua-p-amoadd_w",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "176ffde51adbb98e558a339841b66812",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ua-p-amoadd_w",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ua-p-amoand_w",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "c1c08f2370c095b52f89d5fc1b4ba706",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ua-p-amoand_w",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ua-p-amomaxu_w",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "225f21cd7a361492ef579ff451610fe6",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ua-p-amomaxu_w",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ua-p-amomax_w",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "cb0baf37a96708ba3929ed5974c1b845",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ua-p-amomax_w",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ua-p-amominu_w",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "a6b3eef90fb90fb674d95b8ce023ec3f",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ua-p-amominu_w",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ua-p-amomin_w",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "2766b6dedc65414c7ed545e8bc09f4a6",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ua-p-amomin_w",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ua-p-amoor_w",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "d429a615d785a565abefe5c5aced4625",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ua-p-amoor_w",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ua-p-amoswap_w",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "bdd1f8023d9a94987cba8339aef7d0ac",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ua-p-amoswap_w",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ua-p-amoxor_w",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "69d7195b924363e13e2a8a76b0b27330",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ua-p-amoxor_w",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ua-p-lrsc",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "7eb0c16087856b3f9848081ad1163526",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ua-p-lrsc",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ua-ps-amoadd_w",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "3ba97814b4b4921b08ba5f8dc4f0ba37",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ua-ps-amoadd_w",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ua-ps-amoand_w",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "0dcf8de533e50e5d8d03103ea896e0c8",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ua-ps-amoand_w",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ua-ps-amomaxu_w",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "e8d698149c342c3e04e799dbbba02d70",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ua-ps-amomaxu_w",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ua-ps-amomax_w",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "60ada641b59288b3da0f8cae0269b7a8",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ua-ps-amomax_w",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ua-ps-amominu_w",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "a61c30b47d4ac46bdaed3bd0ddab3afc",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ua-ps-amominu_w",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ua-ps-amomin_w",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "51cd63bdf653564b95d219724c8b80d8",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ua-ps-amomin_w",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ua-ps-amoor_w",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "c4453bcfbc08ab153a45c07aed1340bd",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ua-ps-amoor_w",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ua-ps-amoswap_w",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "75a1054d1c1092ede1ee24acb37d1ce9",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ua-ps-amoswap_w",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ua-ps-amoxor_w",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "e2251724883fc327cedd1e8624437d68",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ua-ps-amoxor_w",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ua-ps-lrsc",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "1d7fb5310b98cecac6c7a2b77c0b864a",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ua-ps-lrsc",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ua-v-amoadd_w",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "5e411fb7bfaadc64e2393691ea0ee171",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ua-v-amoadd_w",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ua-v-amoand_w",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "d0a8cc6f15c599b27ce0c0c59498d50b",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ua-v-amoand_w",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ua-v-amomaxu_w",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "46331052c56ffdab329df1a97096c7e6",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ua-v-amomaxu_w",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ua-v-amomax_w",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "02fffa9cef6a1546e7daced4702c0424",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ua-v-amomax_w",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ua-v-amominu_w",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "b5a6644a543b2e2cf009e8e0e978bdac",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ua-v-amominu_w",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ua-v-amomin_w",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "002ebe22f2a67e383a3e6a16f2df8834",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ua-v-amomin_w",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ua-v-amoor_w",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "fa17f3300dcb12410345b8539f09218f",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ua-v-amoor_w",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ua-v-amoswap_w",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "e0f1992bb53581a96f1ea4a221a2169c",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ua-v-amoswap_w",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ua-v-amoxor_w",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "85763141263db8e5f75b095829d4ffb5",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ua-v-amoxor_w",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ua-v-lrsc",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "221e10a2a57782ff4a66c14a1bd14165",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ua-v-lrsc",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ub-p-andn",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "a42b7e085967aafaf64814779d836c8e",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ub-p-andn",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ub-p-bclr",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "e56c48531dec060dba0ca14ae388d1ee",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ub-p-bclr",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ub-p-bclri",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "fb11ba6e2cad341692d4cb942f285ee3",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ub-p-bclri",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ub-p-bext",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "07183bf3378c6ca7bf363a5ebd35b8f2",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ub-p-bext",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ub-p-bexti",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "abbeef3173a21c4b9753909c18b4ff50",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ub-p-bexti",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ub-p-binv",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "fae7c9ed84e3379d031e98b19cc13b25",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ub-p-binv",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ub-p-binvi",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "d8abbcb9fa4e87b179585eb166d1a057",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ub-p-binvi",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ub-p-bset",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "77ddd4df248cb1805498be196d99ab2a",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ub-p-bset",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ub-p-bseti",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "27258623f788d3b40349f8bb1bcc96fd",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ub-p-bseti",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ub-p-clmul",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "bece3f94e3a71faa5e1821de4fa71098",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ub-p-clmul",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ub-p-clmulh",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "bbc35cc9ac15542b39c24bcec0027d5f",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ub-p-clmulh",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ub-p-clmulr",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "d38e7e9a63850fc754e7a891963b53a6",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ub-p-clmulr",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ub-p-clz",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "e43572f5d2753e2206e37d3414da1922",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ub-p-clz",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ub-p-cpop",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "9e6bcb5814a5f51adddcc412fdfd9e5d",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ub-p-cpop",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ub-p-ctz",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "7924d3f1054f10eb31efff1d73553fe1",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ub-p-ctz",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ub-p-max",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "a97286561ac0cf7266070b8daab7fe9f",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ub-p-max",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ub-p-maxu",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "79bf8b66975c412a9f742b01121b6f39",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ub-p-maxu",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ub-p-min",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "e05406ceb878de004f592d9815e8f7ba",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ub-p-min",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ub-p-minu",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "ac5d17e356599ec8af57198ee0421890",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ub-p-minu",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ub-p-orc_b",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "7c61a91138494b16d6e4d7ec5dbf2a21",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ub-p-orc_b",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ub-p-orn",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "83e468337858aadd8a4267c391812321",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ub-p-orn",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ub-p-rev8",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "386ea87eedd6255e004f20ce9458fbd4",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ub-p-rev8",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ub-p-rol",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "2a3bde79c0ede233110245f4804f5e64",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ub-p-rol",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ub-p-ror",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "e3169b713008ab27dd4eb549b7eca993",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ub-p-ror",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ub-p-rori",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "58f7f2d643e044bc17ad77f2e1513531",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ub-p-rori",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ub-ps-andn",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "c5bab53f62ed34c4bff49fd8df37d30f",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ub-ps-andn",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ub-ps-bclr",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "8f082763b16516603678610a34f9f63f",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ub-ps-bclr",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ub-ps-bclri",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "7ef31a2c21f3d5780cc06980543ab9d8",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ub-ps-bclri",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ub-ps-bext",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "e39ab560d85e4f8260edec4e28a7a785",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ub-ps-bext",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ub-ps-bexti",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "77867aaba72da6cc64c6087282deea22",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ub-ps-bexti",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ub-ps-binv",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "d7db0319cba946584a77b5259382ec57",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ub-ps-binv",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ub-ps-binvi",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "49ce72025be7c4ecdc400f4393acff8a",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ub-ps-binvi",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ub-ps-bset",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "c27e96ebdcd559011e27d562ac06322a",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ub-ps-bset",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ub-ps-bseti",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "c1da32d743cca53c4e99bcf68feafc58",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ub-ps-bseti",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ub-ps-clmul",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "6538a55731fdd11e2734192bc885f093",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ub-ps-clmul",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ub-ps-clmulh",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "5d8d963263bd481567791c187f5d07e0",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ub-ps-clmulh",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ub-ps-clmulr",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "b19c010ba66032c51b54d30dc4b07096",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ub-ps-clmulr",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ub-ps-clz",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "179327a43567bdb111f8c9417c7f0499",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ub-ps-clz",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ub-ps-cpop",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "a355fca5eb1dd4684ba870f0a55c1eb7",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ub-ps-cpop",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ub-ps-ctz",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "f6a64bceeba34dde90e2ee1b32d9433c",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ub-ps-ctz",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ub-p-sext_b",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "a98054bae895c3e23a1d04fcb8ba8fae",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ub-p-sext_b",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ub-p-sext_h",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "a5df4acfa543825289c1b761514b215f",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ub-p-sext_h",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ub-p-sh1add",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "10c3d3347c4c11bfa2c7c9feaf956ae4",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ub-p-sh1add",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ub-p-sh2add",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "9bb44d6b3dcb92aced141f73fc814fa9",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ub-p-sh2add",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ub-p-sh3add",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "8162bb704d68dfc2bc59473c4d98a6fe",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ub-p-sh3add",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ub-ps-max",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "81341621b6c62ab917082690879c899d",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ub-ps-max",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ub-ps-maxu",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "2c31b09add7728431829c0ea54f7551a",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ub-ps-maxu",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ub-ps-min",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "f5fac262410366da90990eef913064ad",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ub-ps-min",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ub-ps-minu",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "7b10dcddebd6d65a2c800da3609d245d",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ub-ps-minu",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ub-ps-orc_b",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "51cd3ebf69ce76e0e027630e298c0046",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ub-ps-orc_b",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ub-ps-orn",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "31391fd7a05b3eedd8b99da2bb7c0be6",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ub-ps-orn",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ub-ps-rev8",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "91c33f5ca058b4b4e96d95021ada413e",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ub-ps-rev8",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ub-ps-rol",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "14181dba22ffb117aa5d9d08bc237c75",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ub-ps-rol",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ub-ps-ror",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "d21730035aab950ae807e15088f36004",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ub-ps-ror",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ub-ps-rori",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "b0376092fe68201d1fec9fb7091c5e9d",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ub-ps-rori",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ub-ps-sext_b",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "ab13ea05fc8bc91bbf48b25afdf1a808",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ub-ps-sext_b",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ub-ps-sext_h",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "ddf22de681970f250575ebb0e2fa1bcf",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ub-ps-sext_h",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ub-ps-sh1add",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "5da85408b0e00a7cc0953db12b4122a1",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ub-ps-sh1add",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ub-ps-sh2add",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "738df5e37c10c1f0e068e346aa0c4f43",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ub-ps-sh2add",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ub-ps-sh3add",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "657f2ddda998cea2bb8d4db3ddbf711c",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ub-ps-sh3add",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ub-ps-xnor",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "ea89af4cd580753435999e54bf52129a",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ub-ps-xnor",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ub-ps-zext_h",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "66b1b7c6d438429eeaa8a1b9ee6d0f4a",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ub-ps-zext_h",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ub-p-xnor",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "e0486bee7a0c00b93b41265dad0e5991",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ub-p-xnor",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ub-p-zext_h",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "5422b5afcac580f6175029a99bf91e04",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ub-p-zext_h",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ub-v-andn",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "bd7bf312573962c3db6942ace826b913",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ub-v-andn",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ub-v-bclr",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "b08cd08ddb3ec98bcee345cb9f4c1860",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ub-v-bclr",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ub-v-bclri",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "9c8e05441b54f6d6319cd901022bac9b",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ub-v-bclri",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ub-v-bext",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "b8c7c3892118f7ea4391e1945fcb3683",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ub-v-bext",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ub-v-bexti",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "93ad8df23451886d91d7dbd716f2dc7a",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ub-v-bexti",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ub-v-binv",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "c8be26500f860f62289bf5030739e498",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ub-v-binv",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ub-v-binvi",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "0df1c457d7c29b2e12065da3102f3283",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ub-v-binvi",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ub-v-bset",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "b9e5f95ff62a13a969695fe03a3c5090",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ub-v-bset",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ub-v-bseti",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "9bcf4b461c4a8a516bb2d8a10b1a3d9f",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ub-v-bseti",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ub-v-clmul",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "b307cab73e0b122599ad2483212e02e3",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ub-v-clmul",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ub-v-clmulh",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "28ba11e2646aad7bbb2c092364e41510",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ub-v-clmulh",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ub-v-clmulr",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "ccee8215a904aaadc106b8c73f1c4b91",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ub-v-clmulr",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ub-v-clz",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "4d170a65fcbb235c837d8ffd6a093b5a",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ub-v-clz",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ub-v-cpop",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "f90bc35a67c0d0e763a9a7c314863df5",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ub-v-cpop",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ub-v-ctz",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "9af2f78f5c7d4708701f97e8143e858a",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ub-v-ctz",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ub-v-max",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "dd659173219717254623a6b322186ea5",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ub-v-max",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ub-v-maxu",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "2481097d53313c772d2df4eb1701030c",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ub-v-maxu",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ub-v-min",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "7542f97c3e51c852990ee25f1357febf",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ub-v-min",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ub-v-minu",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "4aaf23669176f3cdfa17c9bbd670e854",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ub-v-minu",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ub-v-orc_b",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "f38e3d3c9eb0fb73ddab1ac640bb8aff",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ub-v-orc_b",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ub-v-orn",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "ab2ba218914f2f2e177ec8468e25d189",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ub-v-orn",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ub-v-rev8",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "314f6a94963f88a022f4faf6a925e89d",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ub-v-rev8",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ub-v-rol",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "8d7979384e9ae6f788d0ebec491f218d",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ub-v-rol",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ub-v-ror",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "4aa8387830f30b9036340e491a8be993",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ub-v-ror",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ub-v-rori",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "c9352bb1ee73a4ddaadc856fa0642d93",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ub-v-rori",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ub-v-sext_b",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "eb3b2a53897f98d99b4c22cbb6d92f0c",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ub-v-sext_b",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ub-v-sext_h",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "b4ae7ea7c3ff28f1e6ee65139fd9c586",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ub-v-sext_h",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ub-v-sh1add",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "e8dbfc10506dd8599238bf9d846c2cc8",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ub-v-sh1add",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ub-v-sh2add",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "f96bc6039dd6dcae95506cec34feabc7",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ub-v-sh2add",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ub-v-sh3add",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "18507fe0744a200a120b5f9923400cf6",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ub-v-sh3add",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ub-v-xnor",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "5237b376891cb7074d94f7abeb2f66ce",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ub-v-xnor",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ub-v-zext_h",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "f9108c63409957ae468314eb95247480",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ub-v-zext_h",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32uc-p-rvc",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "f3a35479c83342748ea06ee603fa7ce3",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32uc-p-rvc",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32uc-ps-rvc",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "9b70f353cf1e5fe1fa129e5ba1a4076b",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32uc-ps-rvc",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32uc-v-rvc",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "3bd10174f24943d300ad2b3229cc0729",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32uc-v-rvc",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ud-p-fadd",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "5278a43d942b93ccfb6f74c4c198e975",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ud-p-fadd",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ud-p-fclass",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "2537139ff30ced05a0e623795b409d5d",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ud-p-fclass",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ud-p-fcmp",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "9fe82f86459537ec7b7e0d839ae3b873",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ud-p-fcmp",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ud-p-fcvt",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "68926e1323f59ebf8300680d9f82b02c",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ud-p-fcvt",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ud-p-fcvt_w",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "11f33f9e09faf09df49575d02d413ca1",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ud-p-fcvt_w",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ud-p-fdiv",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "9ef7d0364db565770004e1b2bd6fa64f",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ud-p-fdiv",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ud-p-fmadd",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "40dfb0dcef288d357250ed12e2c04104",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ud-p-fmadd",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ud-p-fmin",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "82a53778d66ed5fbfc1e225cfd7dd251",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ud-p-fmin",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ud-p-ldst",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "cb820f3b6019353b2c49a28552508ed9",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ud-p-ldst",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ud-p-recoding",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "27a57fc92a0b874a773a7187ce1b888d",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ud-p-recoding",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ud-ps-fadd",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "cc95dda3bfaaf6b752a78970d6ab9924",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ud-ps-fadd",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ud-ps-fclass",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "62661ddf37a212a52aa9e5848439b41c",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ud-ps-fclass",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ud-ps-fcmp",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "462bfa3d2f96cd79092b75c6197ade11",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ud-ps-fcmp",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ud-ps-fcvt",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "31bb247bd189c9c278f4793cb583fe97",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ud-ps-fcvt",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ud-ps-fcvt_w",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "07236fba14470431ff7df684eed4c769",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ud-ps-fcvt_w",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ud-ps-fdiv",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "b7d743622d735105a4e594d9a4d3ba7b",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ud-ps-fdiv",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ud-ps-fmadd",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "a82f1e39a134d3afb860fafe4ec262cf",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ud-ps-fmadd",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ud-ps-fmin",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "4c5218317305645a4ce6f94282b3891e",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ud-ps-fmin",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ud-ps-ldst",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "9057d58f65017b33fb4fc8360d0f8be0",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ud-ps-ldst",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ud-ps-recoding",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "7302126bfadb13617fadaf36495f4fe0",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ud-ps-recoding",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ud-v-fadd",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "9da372185e3ef05119e1863131bd57f5",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ud-v-fadd",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ud-v-fclass",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "b2874b23906cf58fbaea83fce7bb1327",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ud-v-fclass",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ud-v-fcmp",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "ff072bb1ee1310bd25c2e5ad4da09cac",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ud-v-fcmp",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ud-v-fcvt",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "a910a40a017a519d2317fb687e72c777",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ud-v-fcvt",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ud-v-fcvt_w",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "2d19657fe99e12b25ab6634e1547f964",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ud-v-fcvt_w",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ud-v-fdiv",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "b30fd00e17e778bebb56ab16b11f3ea2",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ud-v-fdiv",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ud-v-fmadd",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "0ceb29a5e97c37174e3f44df111a19cb",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ud-v-fmadd",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ud-v-fmin",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "05f2f12ff46373d748b922c4c9094f69",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ud-v-fmin",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ud-v-ldst",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "1bd1cca10b3936aae2484b1a1691be68",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ud-v-ldst",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ud-v-recoding",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "005bebb05ed89dc463b05dff6d7ae9a4",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ud-v-recoding",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32uf-p-fadd",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "f897b6429b19107a6d1074564a515ff7",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32uf-p-fadd",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32uf-p-fclass",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "0a2f977308a5c573cb2e8989e45c6cf6",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32uf-p-fclass",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32uf-p-fcmp",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "96c402629be3d6338389f2a5f9c6bbaf",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32uf-p-fcmp",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32uf-p-fcvt",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "42b87490ba4565f3505e43c9cde75696",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32uf-p-fcvt",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32uf-p-fcvt_w",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "f316e69a9dff90399f2728d38a4e89ae",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32uf-p-fcvt_w",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32uf-p-fdiv",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "277a58e79692a8cc97832b0854fa601f",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32uf-p-fdiv",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32uf-p-fmadd",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "61b4faf339c5b0e63ffb7bf06133568d",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32uf-p-fmadd",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32uf-p-fmin",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "023e387dbbf23470a6d266bdb7605e2a",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32uf-p-fmin",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32uf-p-ldst",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "b9cabe0fb09b41ba3e194fb0245c7e1a",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32uf-p-ldst",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32uf-p-move",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "ec7498a432d8d05b3f80aabb8ef7b7a5",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32uf-p-move",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32uf-p-recoding",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "a20637f46e576d1187855a4895fa9466",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32uf-p-recoding",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32uf-ps-fadd",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "bb464e2613de73026d0e48f98c0f1af9",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32uf-ps-fadd",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32uf-ps-fclass",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "9a6ff105cb3049ed5fc0723a7fdd2632",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32uf-ps-fclass",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32uf-ps-fcmp",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "4ef79c72c5f7cf02e1b0955eeab6ccd9",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32uf-ps-fcmp",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32uf-ps-fcvt",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "654b1974c5010dc204dc5bd50b0651df",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32uf-ps-fcvt",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32uf-ps-fcvt_w",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "5a1a2653b9b4535c53bbff25a505fdfc",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32uf-ps-fcvt_w",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32uf-ps-fdiv",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "8ebea68fa7a5844d718ecb1b8dbb367c",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32uf-ps-fdiv",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32uf-ps-fmadd",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "28bec41b3155cb262daeea8f65d7a0a1",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32uf-ps-fmadd",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32uf-ps-fmin",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "bd1e87404044db2d2ebaebe89c6206be",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32uf-ps-fmin",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32uf-ps-ldst",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "cd0cc1ee811b59207ec5792c57208898",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32uf-ps-ldst",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32uf-ps-move",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "acc4e343725c8f6007947243f050f32a",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32uf-ps-move",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32uf-ps-recoding",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "18ca86a1764a7e9820bd9629dd902d59",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32uf-ps-recoding",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32uf-v-fadd",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "9e6d4286d2f013c2094863464d1766f5",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32uf-v-fadd",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32uf-v-fclass",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "056954f09b9ae5cba70fbf4ed345f9aa",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32uf-v-fclass",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32uf-v-fcmp",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "542480ff459b7f18405385a44deb14f1",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32uf-v-fcmp",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32uf-v-fcvt",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "ba2f319d8620bb38ff9ebd4f7c5c6dc4",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32uf-v-fcvt",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32uf-v-fcvt_w",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "14ac8999a17598635066d605245ce945",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32uf-v-fcvt_w",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32uf-v-fdiv",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "02aa7a3aa0f72106fba44c281327c3fa",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32uf-v-fdiv",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32uf-v-fmadd",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "58cd3d28cc15c953372bfadcb94c77b6",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32uf-v-fmadd",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32uf-v-fmin",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "89cc50529ffe25b6f6650ca42deabb9c",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32uf-v-fmin",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32uf-v-ldst",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "e43eefad1683b11068df66e81a6cbbfa",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32uf-v-ldst",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32uf-v-move",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "90ab0d8cb1aa26e6aeb15e9288caf0dd",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32uf-v-move",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32uf-v-recoding",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "436c2d83fad61bab4d23cc0b6a9ea4c2",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32uf-v-recoding",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-p-add",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "c1248b3ef9d1e128fe7c5578dcc160b6",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-p-add",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-p-addi",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "43ecfd3083ec78139a2547e97e7dd1b0",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-p-addi",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-p-and",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "2240e896f35d81c1bf1b7b04c54f645f",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-p-and",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-p-andi",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "e63c1886046978c1078166340b5f4101",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-p-andi",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-p-auipc",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "31ce47e29e82cc283304f967b48e6bb2",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-p-auipc",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-p-beq",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "c02a7b41e80101bb081a6ba908a785a1",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-p-beq",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-p-bge",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "3b2d630d68e904378f137fcb57bdcb04",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-p-bge",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-p-bgeu",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "4436c75a4c0e6872e090cbaef3f034e2",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-p-bgeu",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-p-blt",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "dbe589ec00905c77c96ca27e63d27b62",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-p-blt",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-p-bltu",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "a13bcb87a3d9ffc2fd7661b689b9afcd",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-p-bltu",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-p-bne",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "5a0d253b5e07e2b58ab2d038300f7350",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-p-bne",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-p-fence_i",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "e6f63ddd8eb93f04a9b05057a1346374",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-p-fence_i",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-p-jal",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "7f733c1d1105107249277495b099c80a",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-p-jal",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-p-jalr",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "14fcba737d9581687355254a0cd33104",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-p-jalr",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-p-lb",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "a6e4d46f73585a7c7e89ece034494cec",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-p-lb",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-p-lbu",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "a2875e947629d983da61d599e7eacfd8",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-p-lbu",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-p-lh",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "7290a2add7bf8ad09d65252450fd8ebe",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-p-lh",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-p-lhu",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "de00763071e9726bb96a1b45ab37501d",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-p-lhu",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-p-lui",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "ff6e0cbab03336fc9bc5aa558a37aea6",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-p-lui",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-p-lw",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "ee6c1e2e2f3815862f19901cb9925f99",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-p-lw",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-p-or",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "c1272d207ca4b360ca49b2d5dacbc03b",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-p-or",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-p-ori",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "8e95564723e6587e4805e2ff92d0663d",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-p-ori",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-ps-add",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "cfa259dd078bbda40a2421a3fc1b1f99",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-ps-add",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-ps-addi",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "facb31896bbc037490d43cf67319d7c7",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-ps-addi",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-ps-and",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "74abf989fb0327667221824187e06a86",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-ps-and",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-ps-andi",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "1246cdded249e6aa1db2424769b8ae54",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-ps-andi",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-ps-auipc",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "51c86f019c193c9d415061fe07e0b0bf",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-ps-auipc",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-p-sb",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "e21b1cf79cf19f1f961320ed9be5e728",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-p-sb",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-ps-beq",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "103d1c8775097744453aaddfde38274d",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-ps-beq",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-ps-bge",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "08afe85ebf30d30e31420da673cab9fd",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-ps-bge",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-ps-bgeu",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "774eac2b55885eb35c774a50955ae85c",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-ps-bgeu",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-ps-blt",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "88f78d88db1d37c7eb65399e2251820e",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-ps-blt",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-ps-bltu",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "ef76f89f8f03d4878964478adc0fd546",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-ps-bltu",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-ps-bne",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "8f4267a1ead8f81f7381cea820706fb0",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-ps-bne",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-ps-fence_i",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "d3bd834ec9ab747332cc48ec1f2720af",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-ps-fence_i",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-p-sh",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "e770d42d9c98f0f27448513bced3c756",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-p-sh",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-p-simple",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "292b480b09f50c19ae92d1e010ee1430",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-p-simple",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-ps-jal",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "e44e0bbf4979b9b0d30394f54aa44d12",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-ps-jal",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-ps-jalr",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "2f8949b4cce18c0ed44dad71c1be2205",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-ps-jalr",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-ps-lb",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "cd38cb0bed39536770259fffe55cda76",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-ps-lb",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-ps-lbu",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "f5fbf9d34cdd54e41c99ef2100b2ec27",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-ps-lbu",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-ps-lh",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "a66b2005834e9ac81ea47b0b2d214400",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-ps-lh",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-ps-lhu",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "da0892104e89da8d98681fc933d29a6a",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-ps-lhu",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-p-sll",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "f1ba466ca52c8492948cd138e4f3d8de",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-p-sll",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-p-slli",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "4b83c5088cf5250b9ad47780f653ba38",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-p-slli",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-p-slt",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "613e12a680bfbf00e74f36a5c5cc926d",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-p-slt",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-p-slti",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "5d3f4d109673f6d94f49e4037196f651",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-p-slti",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-p-sltiu",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "215c26ccceae91a17a7d46fdd0adfac7",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-p-sltiu",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-p-sltu",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "032c49786fff67cbd30ef00df05ed250",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-p-sltu",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-ps-lui",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "c5eddf988cfb6da78fbc5e44d5172b80",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-ps-lui",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-ps-lw",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "f1e824be7470798f9c27b4e4c1ddc2b3",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-ps-lw",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-ps-or",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "0a205bce395b33442f3115894fb1f611",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-ps-or",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-ps-ori",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "ac29b711db8706746cc558c3d2d93de2",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-ps-ori",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-p-sra",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "edf1940cdac14f9131f7f6e2d4925534",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-p-sra",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-p-srai",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "39b73705da170fd8255ebe87ccafe9d6",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-p-srai",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-p-srl",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "c1bd877889701b1a6c8b9670c606c51d",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-p-srl",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-p-srli",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "5b4f0163bd15e41d76c0163805b6f140",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-p-srli",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-ps-sb",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "b2e787d87b6bd9a78d152e069264a2db",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-ps-sb",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-ps-sh",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "3c4db04c2dada02f776304aed9f6b3c0",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-ps-sh",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-ps-simple",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "34f65fc87fc422768e2a519dc70bbb96",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-ps-simple",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-ps-sll",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "24e848d277f5a13bcfc161ab0e62bf01",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-ps-sll",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-ps-slli",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "ef3fba5b70071f6865ed1745cec97ad8",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-ps-slli",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-ps-slt",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "c0766e57140f5f5279e89c916c4c649b",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-ps-slt",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-ps-slti",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "94fd40a4c33f365bdd4935e5ebce316a",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-ps-slti",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-ps-sltiu",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "c672af0edefa0e418e3aac902cacafb4",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-ps-sltiu",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-ps-sltu",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "43d21b0e0fbe759429211b0da4b0df91",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-ps-sltu",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-ps-sra",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "a3233aa39abfc9a215e14171c2319fc1",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-ps-sra",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-ps-srai",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "7747992df3070d2866d1bfc4d9023ffe",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-ps-srai",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-ps-srl",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "a1e6514aeb147cad45f699ad4b35ac3e",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-ps-srl",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-ps-srli",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "195f95f060f201c635e68ef515c935b3",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-ps-srli",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-ps-sub",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "58b3996d2c172da76bb857c2f4c65e65",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-ps-sub",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-ps-sw",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "c3829041c9231000ba98d8aba00b90d3",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-ps-sw",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-p-sub",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "3efe26e2b91d9209d658cfe974376254",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-p-sub",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-p-sw",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "75f46d5d1acfd3ca7f2da63e4a3041b5",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-p-sw",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-ps-xor",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "19f22dd1c2657a231d4c3fcc7afa080d",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-ps-xor",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-ps-xori",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "7df30aad2e823e96c64bbe00c4dbe208",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-ps-xori",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-p-xor",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "1dbfb88c7ae132b1b7b2ba35e332879c",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-p-xor",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-p-xori",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "ae52003327b68b96334172e56545cfb5",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-p-xori",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-v-add",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "49c63bfa1daa538356326b01d7a4e830",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-v-add",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-v-addi",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "330b8b823e6d4b8c76db87b1ab7828c6",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-v-addi",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-v-and",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "84a0db8252332aec9f76641ebfbbec9a",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-v-and",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-v-andi",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "64c7a12066ce7e7a7bb7b9fd060ca96e",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-v-andi",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-v-auipc",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "84037a3669707810f6102cea94618e48",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-v-auipc",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-v-beq",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "3c24ed0ed34bc569e654735dc07da5fe",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-v-beq",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-v-bge",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "b50304feae76b699a0464924d538de7e",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-v-bge",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-v-bgeu",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "b8d015a66d4133b12b8431169536c2e3",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-v-bgeu",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-v-blt",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "c6458c46099d7ebefb0c9417cc37168f",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-v-blt",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-v-bltu",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "40435e0659e4d019be60469e6374c0f2",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-v-bltu",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-v-bne",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "20be2d7a0b76f32bfcbc90414c298ee9",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-v-bne",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-v-fence_i",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "ff54c4c6f982c5c3bf56dec944da415a",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-v-fence_i",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-v-jal",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "b9eddf41eb9519bda09086150b3fc04a",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-v-jal",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-v-jalr",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "e80911a0c174bbec2285300757a39ade",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-v-jalr",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-v-lb",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "5a8015c61dd4d7c5341dc4e3bdcf2186",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-v-lb",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-v-lbu",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "ea72e96ebe3c9589c48430ca81d9132e",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-v-lbu",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-v-lh",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "b8f1e552a7e82fe349169f8fa6e46f16",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-v-lh",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-v-lhu",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "e6c64ea4cbe1fc209fd032ae64c136ce",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-v-lhu",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-v-lui",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "946a8248d4cfc15d2a1104cae9c26336",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-v-lui",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-v-lw",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "2a4efbf2cbf687e9ef68f7b168c0617f",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-v-lw",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-v-or",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "d3a507bc9fde5ca85954e8b9a40a59a5",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-v-or",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-v-ori",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "e9f069f8829ebbecca23306afe4801b7",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-v-ori",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-v-sb",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "85a72038489d5c618efd9432c452358a",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-v-sb",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-v-sh",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "1eb6b87e94984d0f5c26a2fe9efa2182",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-v-sh",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-v-simple",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "2aec60889551856e0fc94bb3f4559842",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-v-simple",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-v-sll",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "8b5c63126c65cd643ae827c7e8b5580f",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-v-sll",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-v-slli",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "c708316210d8ccd6069504abd7631d36",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-v-slli",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-v-slt",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "6a31cf3eab4257052e5ad881929ead21",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-v-slt",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-v-slti",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "728bf18eb045066527d4502454ab7fdc",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-v-slti",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-v-sltiu",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "6e83904b068ff8637a39d94ce3689c0b",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-v-sltiu",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-v-sltu",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "0dc8ed330dd5bcca92fa637bf7c57cee",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-v-sltu",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-v-sra",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "ef4c7945186592f9123da497d87fc920",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-v-sra",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-v-srai",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "77f984cb73e1a6d41af427833ee6b705",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-v-srai",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-v-srl",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "10679bb1441cf84f023e223c2d2caef8",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-v-srl",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-v-srli",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "e05ed74d5208dcd59a9da95625d49b8f",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-v-srli",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-v-sub",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "0bbe883b60b227529e2d9daaffa5c766",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-v-sub",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-v-sw",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "02153cd8ba97a7ca1cc6b0365c15919d",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-v-sw",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-v-xor",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "0922cf894ec25b154d8f620523412b05",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-v-xor",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32ui-v-xori",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "96ae9f2b8547f45717bf46cf69588807",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32ui-v-xori",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32um-p-div",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "448e82fdbc3b6b4ef0c6baf25b4f50a8",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32um-p-div",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32um-p-divu",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "108a9e6a939198fc02648bd9e2907bd0",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32um-p-divu",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32um-p-mul",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "426f591df2512261941e25d845beab38",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32um-p-mul",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32um-p-mulh",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "e97f8ddcc1473f88fe4e971e2c5a70f2",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32um-p-mulh",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32um-p-mulhsu",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "38a6a167c380f7d7e5fc9bebc92e83f3",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32um-p-mulhsu",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32um-p-mulhu",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "abfcd38dad957ab0e529a0def99cfee7",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32um-p-mulhu",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32um-p-rem",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "350d2d405c0ed0bf70d36d8c6a0fe360",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32um-p-rem",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32um-p-remu",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "8da118334450086e64bee42fc5e90a56",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32um-p-remu",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32um-ps-div",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "07ef84de2856528f6b13b7e7b7e9883d",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32um-ps-div",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32um-ps-divu",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "f7956bad01f6b665ca3215a5aa31cca8",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32um-ps-divu",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32um-ps-mul",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "3b0de0b1bf0599bd1a0581ef100defbb",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32um-ps-mul",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32um-ps-mulh",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "d0fbd656b6b1e7daa926f7bbb7dd554e",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32um-ps-mulh",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32um-ps-mulhsu",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "1dc1875ffb452e74a9123df0bbd4e97f",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32um-ps-mulhsu",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32um-ps-mulhu",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "e9dcd8bb3dcf7499b5f6a89a8cf1b826",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32um-ps-mulhu",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32um-ps-rem",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "aaf7aa804f52092aa2f5584cf867155c",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32um-ps-rem",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32um-ps-remu",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "fd695ee583c33404d65933677b1849fe",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32um-ps-remu",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32um-v-div",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "4648fc7dc10138542a7c710387d7d382",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32um-v-div",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32um-v-divu",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "6fb457b182514e9caa2bc321e52eaa09",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32um-v-divu",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32um-v-mul",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "977074813d2826547e06d0c98396b0d1",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32um-v-mul",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32um-v-mulh",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "d306469fae72ef401c78c4b53b48643b",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32um-v-mulh",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32um-v-mulhsu",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "14c8fed1023bcdff92f67f4355c3cceb",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32um-v-mulhsu",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32um-v-mulhu",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "fb4d8609aa1c281b16befa57ffd4dce7",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32um-v-mulhu",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32um-v-rem",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "086bb0bbea470291848b247cab56116a",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32um-v-rem",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32um-v-remu",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "73b5448477540e855095e06b8183db93",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32um-v-remu",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32uzfh-p-fadd",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "852b8f3f8f3ad75e1621edb427581f00",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32uzfh-p-fadd",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32uzfh-p-fclass",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "e420f92626631d594d7e5408946fb73b",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32uzfh-p-fclass",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32uzfh-p-fcmp",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "91241e49fe4f4aa01e4d62f8d494ccb3",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32uzfh-p-fcmp",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32uzfh-p-fcvt",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "f3e4176737ec2d402c969f7c6aa8c2d7",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32uzfh-p-fcvt",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32uzfh-p-fcvt_w",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "2c56e81730252675e040814f3798029a",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32uzfh-p-fcvt_w",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32uzfh-p-fdiv",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "2d2d2ecd37a5b29c3b539919ee2ad9d2",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32uzfh-p-fdiv",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32uzfh-p-fmadd",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "6d3e37996d36b756a33fe17608b1009b",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32uzfh-p-fmadd",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32uzfh-p-fmin",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "d2f8382f76040c6b9e825d5078c4105b",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32uzfh-p-fmin",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32uzfh-p-ldst",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "df65696dd78ae3d5e99e720cc048343f",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32uzfh-p-ldst",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32uzfh-p-move",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "89c736e4286c46c45f0789bda8c90e04",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32uzfh-p-move",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32uzfh-p-recoding",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "e44ffb5921bbef103d79a8e327d66cc3",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32uzfh-p-recoding",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32uzfh-ps-fadd",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "b75aa2fab7a27f169f335078f2600f1a",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32uzfh-ps-fadd",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32uzfh-ps-fclass",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "6612b5befea8b52e8322249bf7a08ab6",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32uzfh-ps-fclass",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32uzfh-ps-fcmp",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "c2b1f2bf1221ffa440e3fa694a62e901",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32uzfh-ps-fcmp",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32uzfh-ps-fcvt",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "0a724c9436170f542c5281c141a0aecd",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32uzfh-ps-fcvt",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32uzfh-ps-fcvt_w",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "b5df641180c4cbf0ecdd291320863536",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32uzfh-ps-fcvt_w",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32uzfh-ps-fdiv",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "9d4dfc9d8472169c1d259319c3a32ac5",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32uzfh-ps-fdiv",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32uzfh-ps-fmadd",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "c57b3b410478240842288ebf1379c214",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32uzfh-ps-fmadd",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32uzfh-ps-fmin",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "020befdd988d454521014efd61379eb7",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32uzfh-ps-fmin",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32uzfh-ps-ldst",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "682288e981ce302aeade033d1651be65",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32uzfh-ps-ldst",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32uzfh-ps-move",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "fd480ae4098b3652b06dc9be4f57d350",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32uzfh-ps-move",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32uzfh-ps-recoding",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "da891364f63be5e525ebd1f513e48773",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32uzfh-ps-recoding",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32uzfh-v-fadd",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "5c256d37bdbb7d0d593231538cbd87c2",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32uzfh-v-fadd",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32uzfh-v-fclass",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "1c9f81b4ee23a8296cd31bd1179207e4",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32uzfh-v-fclass",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32uzfh-v-fcmp",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "19bc30b0fbf64f90096912c167d7bcad",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32uzfh-v-fcmp",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32uzfh-v-fcvt",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "c9ca358a280a8763d39151273db96f14",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32uzfh-v-fcvt",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32uzfh-v-fcvt_w",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "fe5c11468b7f470789ea188947930c7a",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32uzfh-v-fcvt_w",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32uzfh-v-fdiv",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "a14180d84ed7edbc68aa4fc6f7963794",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32uzfh-v-fdiv",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32uzfh-v-fmadd",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "b904d6cb06bb5b6ac4a375556ba037fa",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32uzfh-v-fmadd",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32uzfh-v-fmin",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "cb20764381e64c39bc289c7a043aa02b",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32uzfh-v-fmin",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32uzfh-v-ldst",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "6fd0feafa81333a6760a4eab99415064",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32uzfh-v-ldst",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32uzfh-v-move",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "197545cd0f44492103391f512b2b5731",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32uzfh-v-move",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv32uzfh-v-recoding",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "97bdcc72d3af57d16a41c7bf99de3078",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv32uzfh-v-recoding",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
                     "name" : "rv64mi-p-access",
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "f79864adb24b4d9d58973fe296555dc3",
+                    "md5sum" : "87f2bc314a4242a7a113ceb2b8d07d9d",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64mi-p-access",
                     "source" : "src/asmtest"
                 },
@@ -668,7 +5030,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "cf9c2c258bc4ee79f6ab725dcd93c8a3",
+                    "md5sum" : "e0d63729a2fa22eedab00067ce5db9ab",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64mi-p-breakpoint",
                     "source" : "src/asmtest"
                 },
@@ -678,7 +5040,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "d184e318ca5583c7459d210af833f67d",
+                    "md5sum" : "547dfcb137136a559524ece52c8fe1e3",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64mi-p-csr",
                     "source" : "src/asmtest"
                 },
@@ -688,7 +5050,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "7f5bb9a8dc5b3556c63f24966edf6ad2",
+                    "md5sum" : "f514fd1af930495047ef30e7df800198",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64mi-p-illegal",
                     "source" : "src/asmtest"
                 },
@@ -698,7 +5060,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "01720cfc720c49af44593fb66e63e06e",
+                    "md5sum" : "7c9b02d59a7ff9f499d56d08c4090241",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64mi-p-ma_addr",
                     "source" : "src/asmtest"
                 },
@@ -708,7 +5070,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "6a8ee354739700aa4da0cf256ae3b623",
+                    "md5sum" : "143813bf1e4862e7cf658bc5513f9782",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64mi-p-ma_fetch",
                     "source" : "src/asmtest"
                 },
@@ -718,7 +5080,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "1894b9678b44a1317bf0fda2bc767443",
+                    "md5sum" : "8a23130159b1fbdeae87ed62afffecc0",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64mi-p-mcsr",
                     "source" : "src/asmtest"
                 },
@@ -728,7 +5090,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "50e24f358eeceb443c18fe4e566957b2",
+                    "md5sum" : "4e70a98b6976969deffff91eed17fba1",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64mi-p-sbreak",
                     "source" : "src/asmtest"
                 },
@@ -738,7 +5100,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "b95617ad90fd92f3f518c626bc1c81fc",
+                    "md5sum" : "ff0964dcda78236fa08f1f315845dc75",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64mi-p-scall",
                     "source" : "src/asmtest"
                 },
@@ -748,7 +5110,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "84dc170bb877dc516f6127371f813087",
+                    "md5sum" : "b0a15cf8b515395468e96523fc086128",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64samt-ps-sysclone_d",
                     "source" : "src/asmtest"
                 },
@@ -758,7 +5120,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "fe859cc6a504d62bc3abbb751b55e416",
+                    "md5sum" : "e3bed4214fdf57c3f545712ea3bef4dd",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64samt-ps-sysfutex1_d",
                     "source" : "src/asmtest"
                 },
@@ -768,7 +5130,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "4a8d53dd89756e6c74ed0925fab72fc4",
+                    "md5sum" : "1c7adcf06943ac5f5754e23f22d8451e",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64samt-ps-sysfutex2_d",
                     "source" : "src/asmtest"
                 },
@@ -778,7 +5140,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "ec61b4108d4c6bb904600a588bb367d3",
+                    "md5sum" : "16366c657fd1996cdca08a193834dbd0",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64samt-ps-sysfutex3_d",
                     "source" : "src/asmtest"
                 },
@@ -788,7 +5150,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "3b805a4400927b59e97a2f678a622f7b",
+                    "md5sum" : "04f2a1302b2fd78704fa8788461fb454",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64samt-ps-sysfutex_d",
                     "source" : "src/asmtest"
                 },
@@ -798,7 +5160,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "fb9db247f8acd3fa330e383942b7170c",
+                    "md5sum" : "60b0d7f900394a85d58c3e6c1397caed",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64si-p-csr",
                     "source" : "src/asmtest"
                 },
@@ -808,7 +5170,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "916747b2226aab4ae7ca05b7eaebc189",
+                    "md5sum" : "ac93b486da58ceb91d4d3062dfdf4c8c",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64si-p-dirty",
                     "source" : "src/asmtest"
                 },
@@ -818,7 +5180,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "bf1d206a09b1b5506533db47d195e354",
+                    "md5sum" : "d9365bbfaa66673cdfb9ee6ed39a049f",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64si-p-icache-alias",
                     "source" : "src/asmtest"
                 },
@@ -828,7 +5190,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "a3451c72e5bc0fecdf34cf8c59ace267",
+                    "md5sum" : "c93d8a25cf4d5e053c78b7fe8759506d",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64si-p-ma_fetch",
                     "source" : "src/asmtest"
                 },
@@ -838,7 +5200,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "08afcd6a559f0625ff2ad490573da7c2",
+                    "md5sum" : "681ed0c4b9c83cff81e222f49f07e60e",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64si-p-sbreak",
                     "source" : "src/asmtest"
                 },
@@ -848,7 +5210,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "08544fc1982fb4223b9516908d73c66e",
+                    "md5sum" : "e88fe285fb7c7e6965eeaa2b7e48d14d",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64si-p-scall",
                     "source" : "src/asmtest"
                 },
@@ -858,578 +5220,8 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "22442bfd1982596f4b7d2ce34256a2d6",
+                    "md5sum" : "3387d3d338d156e4e234da29c08caf89",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64si-p-wfi",
-                    "source" : "src/asmtest"
-                },
-                {
-                    "type" : "resource",
-                    "name" : "rv64ua-p-amoadd_d",
-                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
-                    "architecture" : "RISCV",
-                    "is_zipped" : false,
-                    "md5sum" : "4ae52283ec5265491a331b040faf543c",
-                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-p-amoadd_d",
-                    "source" : "src/asmtest"
-                },
-                {
-                    "type" : "resource",
-                    "name" : "rv64ua-p-amoadd_w",
-                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
-                    "architecture" : "RISCV",
-                    "is_zipped" : false,
-                    "md5sum" : "5317855fb37fdb1eadb141bc5de52c43",
-                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-p-amoadd_w",
-                    "source" : "src/asmtest"
-                },
-                {
-                    "type" : "resource",
-                    "name" : "rv64ua-p-amoand_d",
-                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
-                    "architecture" : "RISCV",
-                    "is_zipped" : false,
-                    "md5sum" : "e7621c3e127790675216e6fafb236ec0",
-                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-p-amoand_d",
-                    "source" : "src/asmtest"
-                },
-                {
-                    "type" : "resource",
-                    "name" : "rv64ua-p-amoand_w",
-                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
-                    "architecture" : "RISCV",
-                    "is_zipped" : false,
-                    "md5sum" : "2f017ecde182922b1039158a9f1252ef",
-                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-p-amoand_w",
-                    "source" : "src/asmtest"
-                },
-                {
-                    "type" : "resource",
-                    "name" : "rv64ua-p-amomax_d",
-                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
-                    "architecture" : "RISCV",
-                    "is_zipped" : false,
-                    "md5sum" : "0a172c82597d9614b93f074d7f4442d4",
-                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-p-amomax_d",
-                    "source" : "src/asmtest"
-                },
-                {
-                    "type" : "resource",
-                    "name" : "rv64ua-p-amomax_w",
-                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
-                    "architecture" : "RISCV",
-                    "is_zipped" : false,
-                    "md5sum" : "089bf05a30b30d1d25f8858d9823087b",
-                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-p-amomax_w",
-                    "source" : "src/asmtest"
-                },
-                {
-                    "type" : "resource",
-                    "name" : "rv64ua-p-amomaxu_d",
-                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
-                    "architecture" : "RISCV",
-                    "is_zipped" : false,
-                    "md5sum" : "82f82aedec0b48994f648082a8a06801",
-                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-p-amomaxu_d",
-                    "source" : "src/asmtest"
-                },
-                {
-                    "type" : "resource",
-                    "name" : "rv64ua-p-amomaxu_w",
-                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
-                    "architecture" : "RISCV",
-                    "is_zipped" : false,
-                    "md5sum" : "c3bfd1da662a92b8685839e85585b342",
-                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-p-amomaxu_w",
-                    "source" : "src/asmtest"
-                },
-                {
-                    "type" : "resource",
-                    "name" : "rv64ua-p-amomin_d",
-                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
-                    "architecture" : "RISCV",
-                    "is_zipped" : false,
-                    "md5sum" : "cb43912d40d8b0eea1ac9fe45557a32c",
-                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-p-amomin_d",
-                    "source" : "src/asmtest"
-                },
-                {
-                    "type" : "resource",
-                    "name" : "rv64ua-p-amomin_w",
-                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
-                    "architecture" : "RISCV",
-                    "is_zipped" : false,
-                    "md5sum" : "cb2488c129deaf82b1945d7617d45b94",
-                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-p-amomin_w",
-                    "source" : "src/asmtest"
-                },
-                {
-                    "type" : "resource",
-                    "name" : "rv64ua-p-amominu_d",
-                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
-                    "architecture" : "RISCV",
-                    "is_zipped" : false,
-                    "md5sum" : "a2cc432c9f969a871b851d6ed7906e25",
-                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-p-amominu_d",
-                    "source" : "src/asmtest"
-                },
-                {
-                    "type" : "resource",
-                    "name" : "rv64ua-p-amominu_w",
-                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
-                    "architecture" : "RISCV",
-                    "is_zipped" : false,
-                    "md5sum" : "796023fb8918ca75353d7850daf14a93",
-                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-p-amominu_w",
-                    "source" : "src/asmtest"
-                },
-                {
-                    "type" : "resource",
-                    "name" : "rv64ua-p-amoor_d",
-                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
-                    "architecture" : "RISCV",
-                    "is_zipped" : false,
-                    "md5sum" : "dc0dc9108bb9bdba7d75ecca8313216c",
-                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-p-amoor_d",
-                    "source" : "src/asmtest"
-                },
-                {
-                    "type" : "resource",
-                    "name" : "rv64ua-p-amoor_w",
-                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
-                    "architecture" : "RISCV",
-                    "is_zipped" : false,
-                    "md5sum" : "4fda30de396c92eaaf16b69c728a3a7d",
-                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-p-amoor_w",
-                    "source" : "src/asmtest"
-                },
-                {
-                    "type" : "resource",
-                    "name" : "rv64ua-p-amoswap_d",
-                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
-                    "architecture" : "RISCV",
-                    "is_zipped" : false,
-                    "md5sum" : "83659ebf6fbd6a57648f1ba8c507aa4b",
-                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-p-amoswap_d",
-                    "source" : "src/asmtest"
-                },
-                {
-                    "type" : "resource",
-                    "name" : "rv64ua-p-amoswap_w",
-                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
-                    "architecture" : "RISCV",
-                    "is_zipped" : false,
-                    "md5sum" : "9d06c8c3ceb069ef86ff2de4815282cd",
-                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-p-amoswap_w",
-                    "source" : "src/asmtest"
-                },
-                {
-                    "type" : "resource",
-                    "name" : "rv64ua-p-amoxor_d",
-                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
-                    "architecture" : "RISCV",
-                    "is_zipped" : false,
-                    "md5sum" : "1af9fab80459fde57f4bf4e9c01d9093",
-                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-p-amoxor_d",
-                    "source" : "src/asmtest"
-                },
-                {
-                    "type" : "resource",
-                    "name" : "rv64ua-p-amoxor_w",
-                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
-                    "architecture" : "RISCV",
-                    "is_zipped" : false,
-                    "md5sum" : "dda14b981718906fc234b8227904c7c6",
-                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-p-amoxor_w",
-                    "source" : "src/asmtest"
-                },
-                {
-                    "type" : "resource",
-                    "name" : "rv64ua-p-lrsc",
-                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
-                    "architecture" : "RISCV",
-                    "is_zipped" : false,
-                    "md5sum" : "8b6ad66b8bbb4df80d1516f6817b7660",
-                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-p-lrsc",
-                    "source" : "src/asmtest"
-                },
-                {
-                    "type" : "resource",
-                    "name" : "rv64ua-ps-amoadd_d",
-                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
-                    "architecture" : "RISCV",
-                    "is_zipped" : false,
-                    "md5sum" : "1f03b3b804be0a2132057003b58f8a2b",
-                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-ps-amoadd_d",
-                    "source" : "src/asmtest"
-                },
-                {
-                    "type" : "resource",
-                    "name" : "rv64ua-ps-amoadd_w",
-                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
-                    "architecture" : "RISCV",
-                    "is_zipped" : false,
-                    "md5sum" : "955744c2e0dbba10ca01e690c0958364",
-                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-ps-amoadd_w",
-                    "source" : "src/asmtest"
-                },
-                {
-                    "type" : "resource",
-                    "name" : "rv64ua-ps-amoand_d",
-                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
-                    "architecture" : "RISCV",
-                    "is_zipped" : false,
-                    "md5sum" : "cc3f74959c923b05340aa24cfc63a801",
-                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-ps-amoand_d",
-                    "source" : "src/asmtest"
-                },
-                {
-                    "type" : "resource",
-                    "name" : "rv64ua-ps-amoand_w",
-                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
-                    "architecture" : "RISCV",
-                    "is_zipped" : false,
-                    "md5sum" : "2c5ad7e346cc4e0e52dfc76789efe397",
-                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-ps-amoand_w",
-                    "source" : "src/asmtest"
-                },
-                {
-                    "type" : "resource",
-                    "name" : "rv64ua-ps-amomax_d",
-                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
-                    "architecture" : "RISCV",
-                    "is_zipped" : false,
-                    "md5sum" : "2123dce5d094f2fc3bc5fb2943562be1",
-                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-ps-amomax_d",
-                    "source" : "src/asmtest"
-                },
-                {
-                    "type" : "resource",
-                    "name" : "rv64ua-ps-amomax_w",
-                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
-                    "architecture" : "RISCV",
-                    "is_zipped" : false,
-                    "md5sum" : "9270905c5113a039b637022170e1fc74",
-                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-ps-amomax_w",
-                    "source" : "src/asmtest"
-                },
-                {
-                    "type" : "resource",
-                    "name" : "rv64ua-ps-amomaxu_d",
-                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
-                    "architecture" : "RISCV",
-                    "is_zipped" : false,
-                    "md5sum" : "808fd2cccbd11f6434b5dcb6c5d3c5bf",
-                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-ps-amomaxu_d",
-                    "source" : "src/asmtest"
-                },
-                {
-                    "type" : "resource",
-                    "name" : "rv64ua-ps-amomaxu_w",
-                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
-                    "architecture" : "RISCV",
-                    "is_zipped" : false,
-                    "md5sum" : "26da4254d99e55fe009c7cc34ac1a987",
-                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-ps-amomaxu_w",
-                    "source" : "src/asmtest"
-                },
-                {
-                    "type" : "resource",
-                    "name" : "rv64ua-ps-amomin_d",
-                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
-                    "architecture" : "RISCV",
-                    "is_zipped" : false,
-                    "md5sum" : "71b99433af69e09f63e0f22d5a02cc49",
-                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-ps-amomin_d",
-                    "source" : "src/asmtest"
-                },
-                {
-                    "type" : "resource",
-                    "name" : "rv64ua-ps-amomin_w",
-                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
-                    "architecture" : "RISCV",
-                    "is_zipped" : false,
-                    "md5sum" : "4f2f90ba9a75b85f9207850e27bb6d00",
-                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-ps-amomin_w",
-                    "source" : "src/asmtest"
-                },
-                {
-                    "type" : "resource",
-                    "name" : "rv64ua-ps-amominu_d",
-                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
-                    "architecture" : "RISCV",
-                    "is_zipped" : false,
-                    "md5sum" : "636269f97f41643f004c259ec446649c",
-                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-ps-amominu_d",
-                    "source" : "src/asmtest"
-                },
-                {
-                    "type" : "resource",
-                    "name" : "rv64ua-ps-amominu_w",
-                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
-                    "architecture" : "RISCV",
-                    "is_zipped" : false,
-                    "md5sum" : "584c473e61733eb5cf58911b3136647a",
-                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-ps-amominu_w",
-                    "source" : "src/asmtest"
-                },
-                {
-                    "type" : "resource",
-                    "name" : "rv64ua-ps-amoor_d",
-                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
-                    "architecture" : "RISCV",
-                    "is_zipped" : false,
-                    "md5sum" : "4729ad637554898b6f26458a104f6b1c",
-                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-ps-amoor_d",
-                    "source" : "src/asmtest"
-                },
-                {
-                    "type" : "resource",
-                    "name" : "rv64ua-ps-amoor_w",
-                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
-                    "architecture" : "RISCV",
-                    "is_zipped" : false,
-                    "md5sum" : "c671e3b095455b8401298009104e92ba",
-                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-ps-amoor_w",
-                    "source" : "src/asmtest"
-                },
-                {
-                    "type" : "resource",
-                    "name" : "rv64ua-ps-amoswap_d",
-                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
-                    "architecture" : "RISCV",
-                    "is_zipped" : false,
-                    "md5sum" : "d4df6b07df820da6eb9eecd8a9029ff7",
-                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-ps-amoswap_d",
-                    "source" : "src/asmtest"
-                },
-                {
-                    "type" : "resource",
-                    "name" : "rv64ua-ps-amoswap_w",
-                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
-                    "architecture" : "RISCV",
-                    "is_zipped" : false,
-                    "md5sum" : "2d9d9d3d6b02cfd4e3506b6b8b4557e7",
-                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-ps-amoswap_w",
-                    "source" : "src/asmtest"
-                },
-                {
-                    "type" : "resource",
-                    "name" : "rv64ua-ps-amoxor_d",
-                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
-                    "architecture" : "RISCV",
-                    "is_zipped" : false,
-                    "md5sum" : "0426ab864eae292dab59998e21b78e49",
-                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-ps-amoxor_d",
-                    "source" : "src/asmtest"
-                },
-                {
-                    "type" : "resource",
-                    "name" : "rv64ua-ps-amoxor_w",
-                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
-                    "architecture" : "RISCV",
-                    "is_zipped" : false,
-                    "md5sum" : "f5c17e8c932aeb0e9dc3ad2a4e0ba168",
-                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-ps-amoxor_w",
-                    "source" : "src/asmtest"
-                },
-                {
-                    "type" : "resource",
-                    "name" : "rv64ua-ps-lrsc",
-                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
-                    "architecture" : "RISCV",
-                    "is_zipped" : false,
-                    "md5sum" : "21090834e56595bfdb9c2fbb89114cb5",
-                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-ps-lrsc",
-                    "source" : "src/asmtest"
-                },
-                {
-                    "type" : "resource",
-                    "name" : "rv64ua-v-amoadd_d",
-                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
-                    "architecture" : "RISCV",
-                    "is_zipped" : false,
-                    "md5sum" : "af091994135470f609cab40bbcea1a63",
-                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-v-amoadd_d",
-                    "source" : "src/asmtest"
-                },
-                {
-                    "type" : "resource",
-                    "name" : "rv64ua-v-amoadd_w",
-                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
-                    "architecture" : "RISCV",
-                    "is_zipped" : false,
-                    "md5sum" : "d78c80bdab8a1fc073fa1f186cec8830",
-                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-v-amoadd_w",
-                    "source" : "src/asmtest"
-                },
-                {
-                    "type" : "resource",
-                    "name" : "rv64ua-v-amoand_d",
-                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
-                    "architecture" : "RISCV",
-                    "is_zipped" : false,
-                    "md5sum" : "1094cdd438411b12f827bf1dcdace80e",
-                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-v-amoand_d",
-                    "source" : "src/asmtest"
-                },
-                {
-                    "type" : "resource",
-                    "name" : "rv64ua-v-amoand_w",
-                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
-                    "architecture" : "RISCV",
-                    "is_zipped" : false,
-                    "md5sum" : "ef5e91a05a48bb7d703841ce8ece84a6",
-                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-v-amoand_w",
-                    "source" : "src/asmtest"
-                },
-                {
-                    "type" : "resource",
-                    "name" : "rv64ua-v-amomax_d",
-                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
-                    "architecture" : "RISCV",
-                    "is_zipped" : false,
-                    "md5sum" : "7ae80f64520e3c110b8bbec945094a53",
-                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-v-amomax_d",
-                    "source" : "src/asmtest"
-                },
-                {
-                    "type" : "resource",
-                    "name" : "rv64ua-v-amomax_w",
-                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
-                    "architecture" : "RISCV",
-                    "is_zipped" : false,
-                    "md5sum" : "701a326352d18dbaffe806c109ad692a",
-                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-v-amomax_w",
-                    "source" : "src/asmtest"
-                },
-                {
-                    "type" : "resource",
-                    "name" : "rv64ua-v-amomaxu_d",
-                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
-                    "architecture" : "RISCV",
-                    "is_zipped" : false,
-                    "md5sum" : "5ef8cc47ea14171f396ddbba188e3983",
-                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-v-amomaxu_d",
-                    "source" : "src/asmtest"
-                },
-                {
-                    "type" : "resource",
-                    "name" : "rv64ua-v-amomaxu_w",
-                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
-                    "architecture" : "RISCV",
-                    "is_zipped" : false,
-                    "md5sum" : "d999a055462eb4179be196d1125d876c",
-                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-v-amomaxu_w",
-                    "source" : "src/asmtest"
-                },
-                {
-                    "type" : "resource",
-                    "name" : "rv64ua-v-amomin_d",
-                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
-                    "architecture" : "RISCV",
-                    "is_zipped" : false,
-                    "md5sum" : "09e4e4d639834b295a665051bf3ce1ef",
-                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-v-amomin_d",
-                    "source" : "src/asmtest"
-                },
-                {
-                    "type" : "resource",
-                    "name" : "rv64ua-v-amomin_w",
-                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
-                    "architecture" : "RISCV",
-                    "is_zipped" : false,
-                    "md5sum" : "179c2591ce919a2488f1e22a0f5d283a",
-                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-v-amomin_w",
-                    "source" : "src/asmtest"
-                },
-                {
-                    "type" : "resource",
-                    "name" : "rv64ua-v-amominu_d",
-                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
-                    "architecture" : "RISCV",
-                    "is_zipped" : false,
-                    "md5sum" : "910ad4686c643213a7829b586002637b",
-                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-v-amominu_d",
-                    "source" : "src/asmtest"
-                },
-                {
-                    "type" : "resource",
-                    "name" : "rv64ua-v-amominu_w",
-                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
-                    "architecture" : "RISCV",
-                    "is_zipped" : false,
-                    "md5sum" : "d808d5cd0398c9ecd5773e50e22abf2e",
-                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-v-amominu_w",
-                    "source" : "src/asmtest"
-                },
-                {
-                    "type" : "resource",
-                    "name" : "rv64ua-v-amoor_d",
-                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
-                    "architecture" : "RISCV",
-                    "is_zipped" : false,
-                    "md5sum" : "de1dcb7d714c669be86c86bd25a85651",
-                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-v-amoor_d",
-                    "source" : "src/asmtest"
-                },
-                {
-                    "type" : "resource",
-                    "name" : "rv64ua-v-amoor_w",
-                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
-                    "architecture" : "RISCV",
-                    "is_zipped" : false,
-                    "md5sum" : "9780206d1b9518b10c8d9e72cf0239eb",
-                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-v-amoor_w",
-                    "source" : "src/asmtest"
-                },
-                {
-                    "type" : "resource",
-                    "name" : "rv64ua-v-amoswap_d",
-                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
-                    "architecture" : "RISCV",
-                    "is_zipped" : false,
-                    "md5sum" : "8cc9a4f1d0b4489d0a0bd70186beaac2",
-                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-v-amoswap_d",
-                    "source" : "src/asmtest"
-                },
-                {
-                    "type" : "resource",
-                    "name" : "rv64ua-v-amoswap_w",
-                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
-                    "architecture" : "RISCV",
-                    "is_zipped" : false,
-                    "md5sum" : "eca745d0dbe4ae57fe6b110317834875",
-                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-v-amoswap_w",
-                    "source" : "src/asmtest"
-                },
-                {
-                    "type" : "resource",
-                    "name" : "rv64ua-v-amoxor_d",
-                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
-                    "architecture" : "RISCV",
-                    "is_zipped" : false,
-                    "md5sum" : "3bbee5900b7d9e540ce212f4dd423c7d",
-                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-v-amoxor_d",
-                    "source" : "src/asmtest"
-                },
-                {
-                    "type" : "resource",
-                    "name" : "rv64ua-v-amoxor_w",
-                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
-                    "architecture" : "RISCV",
-                    "is_zipped" : false,
-                    "md5sum" : "8fb3a2fb5d50813d077d80210d010828",
-                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-v-amoxor_w",
-                    "source" : "src/asmtest"
-                },
-                {
-                    "type" : "resource",
-                    "name" : "rv64ua-v-lrsc",
-                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
-                    "architecture" : "RISCV",
-                    "is_zipped" : false,
-                    "md5sum" : "932d6654d7a960b455dff6f09d5f69ea",
-                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-v-lrsc",
                     "source" : "src/asmtest"
                 },
                 {
@@ -1438,7 +5230,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "87b684a2f6bb281d7ad4b7b042b73854",
+                    "md5sum" : "c8773a188b9ccfe71e41a11c03cc2230",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64uamt-ps-amoadd_d",
                     "source" : "src/asmtest"
                 },
@@ -1448,7 +5240,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "24ccac26314dc1f05928f8244cb0cbe7",
+                    "md5sum" : "29a45af26e744a2e38c65eac5fd5356d",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64uamt-ps-amoand_d",
                     "source" : "src/asmtest"
                 },
@@ -1458,7 +5250,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "e713e0e561b53e56f9339f67b663ca9c",
+                    "md5sum" : "01457e8817cc7848b0ed5702909b8979",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64uamt-ps-amomax_d",
                     "source" : "src/asmtest"
                 },
@@ -1468,7 +5260,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "da2bf05a420e75221056003767c878a8",
+                    "md5sum" : "2cbd255e36a074100c2ee3774f4d0087",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64uamt-ps-amomaxu_d",
                     "source" : "src/asmtest"
                 },
@@ -1478,7 +5270,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "97e120b06112fa2def234de4fede74ab",
+                    "md5sum" : "ef7cd9d779aa8070b7b90bee5ca2bb52",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64uamt-ps-amomin_d",
                     "source" : "src/asmtest"
                 },
@@ -1488,7 +5280,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "8ea0a86db7b7e02ae78d4f07374ab52f",
+                    "md5sum" : "adcf9385ee1c166c34c561fa2c87665d",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64uamt-ps-amominu_d",
                     "source" : "src/asmtest"
                 },
@@ -1498,7 +5290,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "b5f540731786f31803c3c60237623fe6",
+                    "md5sum" : "8cde7d8a05e1e7e2ab45651fc651643a",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64uamt-ps-amoor_d",
                     "source" : "src/asmtest"
                 },
@@ -1508,7 +5300,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "3775368c4726324b66150ea3f9d2a260",
+                    "md5sum" : "8eb231b7a0a52871c9f03b4708f76785",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64uamt-ps-amoswap_d",
                     "source" : "src/asmtest"
                 },
@@ -1518,7 +5310,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "57e926bd3326d5559e592c27c32e53fb",
+                    "md5sum" : "cd83ee2d69f8864184e5ec0a3fff8a31",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64uamt-ps-amoxor_d",
                     "source" : "src/asmtest"
                 },
@@ -1528,8 +5320,1868 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "70ff384c8ef9b66e564a273e9e6d2648",
+                    "md5sum" : "b0a08db0c11828ea5d55418bdbd5e6a4",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64uamt-ps-lrsc_d",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ua-p-amoadd_d",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "f3613f54f0dabbab0380e7c66554d6ab",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-p-amoadd_d",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ua-p-amoadd_w",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "2ed1080f2ff16b592a9e3c1b5cf4583e",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-p-amoadd_w",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ua-p-amoand_d",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "7ae319f2a9466f025ca9098c4bf015b7",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-p-amoand_d",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ua-p-amoand_w",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "9d8e86f1e0fed8c6433d43a1077d9655",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-p-amoand_w",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ua-p-amomax_d",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "4a96a6cfb2aa56a92ac6b3c49a0f4c2f",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-p-amomax_d",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ua-p-amomaxu_d",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "96cf34e45b0f4c247d7c117233b6318a",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-p-amomaxu_d",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ua-p-amomaxu_w",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "1e7d267cc111d805f45b0cbde2057a2a",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-p-amomaxu_w",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ua-p-amomax_w",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "5b7abd6a0451f0667aa5b35b690202d0",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-p-amomax_w",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ua-p-amomin_d",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "d877ed61742ad8951368830cb4c8302c",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-p-amomin_d",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ua-p-amominu_d",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "e2144ac34cce30a0c6009ad945a48ece",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-p-amominu_d",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ua-p-amominu_w",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "5e70801991fb1be20c29d0a4a621f8a5",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-p-amominu_w",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ua-p-amomin_w",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "e86337c3814c221d08de951ecec8a4bb",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-p-amomin_w",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ua-p-amoor_d",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "62e563555445e56e31814f96fa177129",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-p-amoor_d",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ua-p-amoor_w",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "ae2d5ebed9295cd4820e8772b04f5608",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-p-amoor_w",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ua-p-amoswap_d",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "430ed3acb5db24929a8a8bea258ff21e",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-p-amoswap_d",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ua-p-amoswap_w",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "6d3cdc6ada89cfd395a14fc860e918a7",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-p-amoswap_w",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ua-p-amoxor_d",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "1a35071cd9efda9bff0fa6fb2635ab60",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-p-amoxor_d",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ua-p-amoxor_w",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "9f5b7761264f90b073dd2d4cdba505f9",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-p-amoxor_w",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ua-p-lrsc",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "a8ca0c8709b3a10c1519a2bcab859819",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-p-lrsc",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ua-ps-amoadd_d",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "d2e4af1861e84735f825a82a3f7d2989",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-ps-amoadd_d",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ua-ps-amoadd_w",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "35f73ee69c8b5819d0a3c9654b1bd302",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-ps-amoadd_w",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ua-ps-amoand_d",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "62e898e7e39b55692f03370c25e0afe7",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-ps-amoand_d",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ua-ps-amoand_w",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "c77361021444d2f0232dfb7afe5d242a",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-ps-amoand_w",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ua-ps-amomax_d",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "eae001149889be1f1e586052fdcc3c0d",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-ps-amomax_d",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ua-ps-amomaxu_d",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "dad2b431af5cba1c81fc24c09c1478fc",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-ps-amomaxu_d",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ua-ps-amomaxu_w",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "b82fdcd6823eb92ad2040ac7de042839",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-ps-amomaxu_w",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ua-ps-amomax_w",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "c1faccab6a50eb8fa99335e2dd887702",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-ps-amomax_w",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ua-ps-amomin_d",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "d8818f2153bcc4f39189beb2c48ab5ac",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-ps-amomin_d",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ua-ps-amominu_d",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "06fee43e3fc4bec0a486fdae43b6efcd",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-ps-amominu_d",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ua-ps-amominu_w",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "4c8dcb4d18395746f95696b50e848a14",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-ps-amominu_w",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ua-ps-amomin_w",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "1407ad1ba239f6869b685927bd386e6b",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-ps-amomin_w",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ua-ps-amoor_d",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "9ff2e1fe6caba22334be088f22e7e7b7",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-ps-amoor_d",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ua-ps-amoor_w",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "5d5398715949e9fbf29095900e16f45b",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-ps-amoor_w",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ua-ps-amoswap_d",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "8ad80b40a4048c4841e536392b21e0cd",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-ps-amoswap_d",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ua-ps-amoswap_w",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "726f163dc2cbd8f096b9347f9b2f9ae5",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-ps-amoswap_w",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ua-ps-amoxor_d",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "4b7ff9086f5614acd8c684bd2de85caf",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-ps-amoxor_d",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ua-ps-amoxor_w",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "315c709b501052ae3fdc389ea74dc0d9",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-ps-amoxor_w",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ua-ps-lrsc",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "ca6ec09c17b5e0643ce31dd9db80df22",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-ps-lrsc",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ua-v-amoadd_d",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "370597deed8e904b443a18c985b616df",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-v-amoadd_d",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ua-v-amoadd_w",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "1f5c54bc327b7602834d6bd1274f7190",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-v-amoadd_w",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ua-v-amoand_d",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "4980d50f70d9a3dbbe30d61fcc98594b",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-v-amoand_d",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ua-v-amoand_w",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "ec373b818b9d18588ea6656ae988b521",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-v-amoand_w",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ua-v-amomax_d",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "eafa1cb04bb6001341fc1598e5399b6b",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-v-amomax_d",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ua-v-amomaxu_d",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "859057d542351a9dd635850230988e09",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-v-amomaxu_d",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ua-v-amomaxu_w",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "3d36361506a31f6bcd977ae60cfede97",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-v-amomaxu_w",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ua-v-amomax_w",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "ddaf277d2e6c6b8511e41ffa310d4333",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-v-amomax_w",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ua-v-amomin_d",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "d1e661d31557d2d26e590ac4c17f7fd0",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-v-amomin_d",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ua-v-amominu_d",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "10bf396fa287ec2ce237580a56af66df",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-v-amominu_d",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ua-v-amominu_w",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "c394c1e007e0df719da2453751ca6ea1",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-v-amominu_w",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ua-v-amomin_w",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "5bbd3e8d873056ec549e6ac36f41c74a",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-v-amomin_w",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ua-v-amoor_d",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "ae0e7744ff257c96eb03371dbbe5e5ba",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-v-amoor_d",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ua-v-amoor_w",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "4ecc92bf184b760b0a6699023ee5ae98",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-v-amoor_w",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ua-v-amoswap_d",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "03379dc8a8416afb3dbb1df946dac0f1",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-v-amoswap_d",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ua-v-amoswap_w",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "1251760b4200d9ec2e2d74bb98da05da",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-v-amoswap_w",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ua-v-amoxor_d",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "6553db4962429346ea41f2683c027a0e",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-v-amoxor_d",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ua-v-amoxor_w",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "cf3b362eb4e60b8f9c1ee64034496e22",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-v-amoxor_w",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ua-v-lrsc",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "0019a9baf33dc066fb717d2ce8e2de03",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ua-v-lrsc",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-p-add_uw",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "23f16c7f66b3ce3b86e08d6118ca95e3",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-p-add_uw",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-p-andn",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "4cea3366b69cae731c937ce45c37fbfd",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-p-andn",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-p-bclr",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "9b27a64653b764614ceb7e960a7072ff",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-p-bclr",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-p-bclri",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "2fcf9b7ce115ce8ef145c04c7a58efbe",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-p-bclri",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-p-bext",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "e9db5878476ff3ee25a1058c93c015d0",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-p-bext",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-p-bexti",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "6d84ba8ea7deaf8551064f43c886ebd9",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-p-bexti",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-p-binv",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "41ad1beed78669e72c889fbdd69696da",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-p-binv",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-p-binvi",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "f0b5a0d292b25f72b97f612adb5bb07f",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-p-binvi",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-p-bset",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "f03a89f5922f5a165767588a577f88f2",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-p-bset",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-p-bseti",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "302e709896de340990e2996fd6c2546e",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-p-bseti",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-p-clmul",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "ce2bca8a0a55dfc40ec59c2dea247ca3",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-p-clmul",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-p-clmulh",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "8367e98d9e5d69d98907e08c9ee7bc21",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-p-clmulh",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-p-clmulr",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "9468a3e38a84ded46f7b8a15176f7d6f",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-p-clmulr",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-p-clz",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "203dda20c63d9b6ec1a702ab6f234626",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-p-clz",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-p-clzw",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "ef1baa80a1da71dafe3edf883504fb02",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-p-clzw",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-p-cpop",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "b018a25a3139efdf3779485926e255f7",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-p-cpop",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-p-cpopw",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "f5b5452b8851c94f042d34cc729f168e",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-p-cpopw",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-p-ctz",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "2e0cf00adf5d37df87ab0ce5c3d5edac",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-p-ctz",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-p-ctzw",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "5b05b6dd32cfbdb09cb558c83cf5a834",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-p-ctzw",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-p-max",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "f7031e5ce6c2f3b6b696159df10fde5e",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-p-max",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-p-maxu",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "4be2efca81245691d78daebca0a8cbea",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-p-maxu",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-p-min",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "7dff18be41d693acac09f546fb551a11",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-p-min",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-p-minu",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "2bd8c187a3b274d96ed7c45805f117a1",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-p-minu",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-p-orc_b",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "8a021e4e92d5b6655dfc7d7050bd0fc6",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-p-orc_b",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-p-orn",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "66800f8f7cad82143acb525d3de59c77",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-p-orn",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-p-rev8",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "8bb8194cac55ddea08aac61d38a7b07b",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-p-rev8",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-p-rol",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "b4ad933829781725c309e7979ceee9fc",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-p-rol",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-p-rolw",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "0e5acffb92822484d9960e83e0a0ebe7",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-p-rolw",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-p-ror",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "6393d369e5dc8bdfb935afb46d639884",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-p-ror",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-p-rori",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "7a49058e70c3f8bfe21c311cf0cbe8e2",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-p-rori",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-p-roriw",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "e3a2078fa44186e83dfe197ceac0c624",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-p-roriw",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-p-rorw",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "781c74f7b7e50840e65a9d1a9f531c39",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-p-rorw",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-ps-add_uw",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "64b05c99a92d9e3db8de0885da282891",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-ps-add_uw",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-ps-andn",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "a27ec21afcb36655bbf6ec051dbfb95e",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-ps-andn",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-ps-bclr",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "0c7825583c608baad5a1a9773eb8be27",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-ps-bclr",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-ps-bclri",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "5c96139dd961a37182d7c08e7f72ac71",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-ps-bclri",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-ps-bext",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "c4ca98a092f2c0ca18f0791bfb04ed92",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-ps-bext",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-ps-bexti",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "a67655ecaaef89a5837edbd7a4aeec5e",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-ps-bexti",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-ps-binv",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "1faa27dd5c1acac9c83db03e766ab8a7",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-ps-binv",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-ps-binvi",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "f3abda1519d7fb52602abbcdacfc4e9e",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-ps-binvi",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-ps-bset",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "bfc2d1662ff3e0a0d6eec57f37706497",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-ps-bset",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-ps-bseti",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "c9890d33fa0ec133fd640a42e456a20e",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-ps-bseti",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-ps-clmul",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "2428a24e8c667beede7a75b30bbfcf56",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-ps-clmul",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-ps-clmulh",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "f8d4057790eec67c998d942c7b7e5c0e",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-ps-clmulh",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-ps-clmulr",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "384a9bd10602d1d50dc0cd66ea855584",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-ps-clmulr",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-ps-clz",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "ad030784bd3380e8e7ff42d39064e109",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-ps-clz",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-ps-clzw",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "6a9e4875f14cc6c6aea9590543da59f1",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-ps-clzw",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-ps-cpop",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "0499d9e3d84d3a27e1914ff1e2ce997a",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-ps-cpop",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-ps-cpopw",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "e66b212987cff99e9d3b979398d58221",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-ps-cpopw",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-ps-ctz",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "615228cf5ae753b36480509cec7f5219",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-ps-ctz",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-ps-ctzw",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "a7f12fb945486eea617e29fe15e90ee9",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-ps-ctzw",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-p-sext_b",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "2b9c8d1f23a0a81a498ed42907b3eda6",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-p-sext_b",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-p-sext_h",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "98309089fae7ab2ea42b9a1e06bef871",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-p-sext_h",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-p-sh1add",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "6d67d95b75cecbedadc76ed70ef196bb",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-p-sh1add",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-p-sh1add_uw",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "2a19dd5bef06b4b36e2d739d924b160d",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-p-sh1add_uw",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-p-sh2add",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "c00709b3ea1b38886bdb1547839927ae",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-p-sh2add",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-p-sh2add_uw",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "8eb5446073d08b43fcfb56d67ad02022",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-p-sh2add_uw",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-p-sh3add",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "10b025086d16b56e296d7e7a17ba6784",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-p-sh3add",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-p-sh3add_uw",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "62519b1279d87a2a84c3f9b61cb3d23f",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-p-sh3add_uw",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-p-slli_uw",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "99dd069e379592b4bfd13ec1bd2e2fc2",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-p-slli_uw",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-ps-max",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "51fe49a5f318b78fc63471a8c768a924",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-ps-max",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-ps-maxu",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "f6f9064cd9c630521d0e54e39b9cff58",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-ps-maxu",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-ps-min",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "c451168b397997ec8361d385a93ea5dc",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-ps-min",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-ps-minu",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "c908d6ba0e41d6534b2916bb9a946657",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-ps-minu",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-ps-orc_b",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "12862a6dc47af76c4d043efbb571af77",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-ps-orc_b",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-ps-orn",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "fa0aa155db19d2a9df7faa68b74a4226",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-ps-orn",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-ps-rev8",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "19bdde61e6afed173d2ca27230fa2004",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-ps-rev8",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-ps-rol",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "8233a40b22e14e08157d05c1fad8086c",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-ps-rol",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-ps-rolw",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "3a4dc0e35a08accf515456ed93979bd4",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-ps-rolw",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-ps-ror",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "7013c74723baab83bcd11f10dc959b29",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-ps-ror",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-ps-rori",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "b88c002eefdbf91e50b194bca998e9b9",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-ps-rori",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-ps-roriw",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "250a8498f3aea2b7dda36f31851c301e",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-ps-roriw",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-ps-rorw",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "67b60ea3c85b48b99dfac5f94e0e1ee8",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-ps-rorw",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-ps-sext_b",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "a79e1241f67852b1e766dd8e93b02e89",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-ps-sext_b",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-ps-sext_h",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "1bfaed162834043333d79dbb5ec31eaf",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-ps-sext_h",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-ps-sh1add",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "ed0a289ba9ff04e3207cbef8500c9c53",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-ps-sh1add",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-ps-sh1add_uw",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "3aa14d0f95126c53305d362fc5476144",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-ps-sh1add_uw",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-ps-sh2add",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "0146bbbf0e212834f8b19bb93c6a5a77",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-ps-sh2add",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-ps-sh2add_uw",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "c524ab16cc9a6f1a8741831ceb1c687a",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-ps-sh2add_uw",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-ps-sh3add",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "a034737da8fb55ebf264b9f39736779e",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-ps-sh3add",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-ps-sh3add_uw",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "6b6962e34fa06debdd69e1298b8f8c4e",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-ps-sh3add_uw",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-ps-slli_uw",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "be56daf86db447617f85ea578c88e725",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-ps-slli_uw",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-ps-xnor",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "41f51599054296e6de153ca271c4d2bd",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-ps-xnor",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-ps-zext_h",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "7f22d40586e8419286d00d289ebd141a",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-ps-zext_h",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-p-xnor",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "f23aa14646a203105fe6cf89df0d8134",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-p-xnor",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-p-zext_h",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "a09928395414a9dbd6769d50e8c08885",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-p-zext_h",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-v-add_uw",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "939d7ceaede78f4c4a8b049606425949",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-v-add_uw",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-v-andn",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "3be2f311637f72dd96370336f9951bf6",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-v-andn",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-v-bclr",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "7fd16f20029c1dc14b29bca976eac339",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-v-bclr",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-v-bclri",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "5849b5166d93dfb9c3724b80d3fcb02e",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-v-bclri",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-v-bext",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "fe4153c514c42ca50aa549f2b2e5c44f",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-v-bext",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-v-bexti",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "b0cd1976fcc49635ff0780d875aba1af",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-v-bexti",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-v-binv",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "bf17345abb50ac43ff70db31dcae7a9f",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-v-binv",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-v-binvi",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "920da8920239b35a61e381c5f8b2808f",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-v-binvi",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-v-bset",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "3ce7d528af70715cc27bb2e6db035c94",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-v-bset",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-v-bseti",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "b8ea4afa43f77a787ee9b099c8822483",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-v-bseti",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-v-clmul",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "b6832eaeb700ef0d50fd0086c79036c0",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-v-clmul",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-v-clmulh",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "5286e2967af9a3855ce2d6ef3d3978a0",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-v-clmulh",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-v-clmulr",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "2a40d0c4e4d2abfa62cc07ba84ceb11b",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-v-clmulr",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-v-clz",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "66744b021995f0528a5e2922a643eda1",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-v-clz",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-v-clzw",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "1567dc42bb997e73094d61dc7cc3ddb0",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-v-clzw",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-v-cpop",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "6c68527b006803164f2cfea2a8c99b36",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-v-cpop",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-v-cpopw",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "2d3046412521c7dacb1425a1883c5e19",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-v-cpopw",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-v-ctz",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "93288fa007ba08394b9842ebb4ed101b",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-v-ctz",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-v-ctzw",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "904634b501d39465cd6d00d18a127b17",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-v-ctzw",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-v-max",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "6b1371e7c0adabb196385261dc3a7f2a",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-v-max",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-v-maxu",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "90eeeaa0addd1f44585199b6fe446a6b",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-v-maxu",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-v-min",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "ccbea3a6bd49f07ce8b6633e6b1256c6",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-v-min",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-v-minu",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "4eac86524a5226762692b3888d6c6863",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-v-minu",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-v-orc_b",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "146239bf41f5b651fe95951f80261510",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-v-orc_b",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-v-orn",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "e6ccb21e430f8bf36e860be02efae700",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-v-orn",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-v-rev8",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "866318e38cd4f7edaf4c2fb95437c73a",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-v-rev8",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-v-rol",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "daa890cdb40a74164662b8a1c9ef388a",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-v-rol",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-v-rolw",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "ea5a365b9f1b20b52c5b62821ae12ebd",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-v-rolw",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-v-ror",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "f531f4b5b6621d95fa61ae6dcb405cc1",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-v-ror",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-v-rori",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "890e4cdf8e07264f2aaed5fc0f2f915b",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-v-rori",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-v-roriw",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "2cc70d8912bc54a35ae145c992ca0fb1",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-v-roriw",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-v-rorw",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "9e60ada36f54534a1fb4f416ce186054",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-v-rorw",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-v-sext_b",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "fc36fd2fbcd91bcd40eeba8b5f85ad0c",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-v-sext_b",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-v-sext_h",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "187120a58f17e480dee0492879eb4c46",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-v-sext_h",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-v-sh1add",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "39939cd3040eb1f804e4f376234e90df",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-v-sh1add",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-v-sh1add_uw",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "7033f0502f554418f77051e5d31be24c",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-v-sh1add_uw",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-v-sh2add",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "fbc87e590f866b98f9e9d169fd37757d",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-v-sh2add",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-v-sh2add_uw",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "67ad28fea9baccacf7ca8ee387b37e41",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-v-sh2add_uw",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-v-sh3add",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "9ec42ca2c71806382c31f643c1f897c7",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-v-sh3add",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-v-sh3add_uw",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "5433decbdeddf1dcec265c09d7bc3cbf",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-v-sh3add_uw",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-v-slli_uw",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "061dfc90d7e21747af705a3d319c5cb2",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-v-slli_uw",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-v-xnor",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "80e581a6333aa19cf72d48ac49565fd8",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-v-xnor",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ub-v-zext_h",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "cde046d406cedfbd7523135f86026e6f",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ub-v-zext_h",
                     "source" : "src/asmtest"
                 },
                 {
@@ -1538,8 +7190,18 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "6a75f689b2bd4582a43bdbbb31bb382c",
+                    "md5sum" : "9eba5b05c02dc43b976a2bacd24a7619",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64uc-p-rvc",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64uc-ps-rvc",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "4a7f4ad3dd835db0268bf5385754faaa",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64uc-ps-rvc",
                     "source" : "src/asmtest"
                 },
                 {
@@ -1548,7 +7210,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "5fe84fedbeb130f5817c0fe0a5584b3e",
+                    "md5sum" : "bc427b400df41464f90a045158e3f232",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64uc-v-rvc",
                     "source" : "src/asmtest"
                 },
@@ -1558,7 +7220,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "df0e68e382a89931501e2cc46314ff3b",
+                    "md5sum" : "2311da9b5e6a06f3fd8d170be9f943e6",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ud-p-fadd",
                     "source" : "src/asmtest"
                 },
@@ -1568,7 +7230,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "9ba1f2aab1822501ce977b7a2c7c4a6b",
+                    "md5sum" : "d6792e7a6cc45cc74427d25f8055a0ae",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ud-p-fclass",
                     "source" : "src/asmtest"
                 },
@@ -1578,7 +7240,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "46e7f1ce5cd54bf2d3419d84c0153f24",
+                    "md5sum" : "2bdf102996de8fc792ebc01a8ba5cbee",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ud-p-fcmp",
                     "source" : "src/asmtest"
                 },
@@ -1588,7 +7250,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "581531f02f3c135ed2c4ad6bd4ab6ee4",
+                    "md5sum" : "96f78a1026d0c8c738dc398f4507b8c3",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ud-p-fcvt",
                     "source" : "src/asmtest"
                 },
@@ -1598,7 +7260,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "7a937a695c44129aa6d182d435a421fc",
+                    "md5sum" : "c61b4350dba0aed220e7feb257bb20ce",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ud-p-fcvt_w",
                     "source" : "src/asmtest"
                 },
@@ -1608,7 +7270,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "ec2ce086d1bbe1b29622f70c7901abd8",
+                    "md5sum" : "84a471ab88bd8a4bdd355e00b37cefe9",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ud-p-fdiv",
                     "source" : "src/asmtest"
                 },
@@ -1618,7 +7280,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "e7163e05deadb1bfc22b81ba448a860f",
+                    "md5sum" : "c1416e0d87cc3319e17bf1819a14196d",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ud-p-fmadd",
                     "source" : "src/asmtest"
                 },
@@ -1628,7 +7290,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "e2b6014cf013c294ad91558fe2f0ed21",
+                    "md5sum" : "4a6fb845e9be17df7d7acbf3abbbc144",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ud-p-fmin",
                     "source" : "src/asmtest"
                 },
@@ -1638,7 +7300,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "d9ba4fff56f725ea79d0e70862247c44",
+                    "md5sum" : "807b423b223fad7f3cad1415013a7369",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ud-p-ldst",
                     "source" : "src/asmtest"
                 },
@@ -1648,7 +7310,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "ba51a7c9ac36c0f2258863e6c8a7bd0a",
+                    "md5sum" : "9876a93729a16585e006532687594608",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ud-p-move",
                     "source" : "src/asmtest"
                 },
@@ -1658,18 +7320,8 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "fc2e947926e128c983a957783f32daae",
+                    "md5sum" : "d3b178c6943c2b895f2734e5b7f88529",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ud-p-recoding",
-                    "source" : "src/asmtest"
-                },
-                {
-                    "type" : "resource",
-                    "name" : "rv64ud-p-structural",
-                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
-                    "architecture" : "RISCV",
-                    "is_zipped" : false,
-                    "md5sum" : "a3a59386a27eea3f80f5461216c3344d",
-                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ud-p-structural",
                     "source" : "src/asmtest"
                 },
                 {
@@ -1678,7 +7330,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "fc8de228dd951868fb274786b6ff9ff9",
+                    "md5sum" : "5c7c0d0f99cdd316197954f278565dee",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ud-ps-fadd",
                     "source" : "src/asmtest"
                 },
@@ -1688,7 +7340,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "da76a1a5ed8c450e5fa76a4c27079bb6",
+                    "md5sum" : "77a4e9076bddb119ed723315be0cb8df",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ud-ps-fclass",
                     "source" : "src/asmtest"
                 },
@@ -1698,7 +7350,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "aa42a6da32ee329295640ebba07de718",
+                    "md5sum" : "e8d4f4371fa9546e9158f9845f74ee1f",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ud-ps-fcmp",
                     "source" : "src/asmtest"
                 },
@@ -1708,7 +7360,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "87e11c0fa32e8ff3fd9a9f1781a91bb7",
+                    "md5sum" : "ea8ce7e55a7e1686bae9942118ccef5e",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ud-ps-fcvt",
                     "source" : "src/asmtest"
                 },
@@ -1718,7 +7370,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "e2bb2d9995a606521e443713a99ac569",
+                    "md5sum" : "a4ca032b9e9db851b71edb4f296df3a1",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ud-ps-fcvt_w",
                     "source" : "src/asmtest"
                 },
@@ -1728,7 +7380,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "1aa837b6dccf2e11aceebed8d3a6a991",
+                    "md5sum" : "b87ef91bd79e2a410b33e4ffd2e1533e",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ud-ps-fdiv",
                     "source" : "src/asmtest"
                 },
@@ -1738,7 +7390,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "3125478135067cf9b44dfae5c4b6df31",
+                    "md5sum" : "e9115964a206447456a7a9509f6d349d",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ud-ps-fmadd",
                     "source" : "src/asmtest"
                 },
@@ -1748,7 +7400,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "3cee89db4e4881f0f0f903114bf00fe0",
+                    "md5sum" : "940b13a881234e16bf75af0c096866d7",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ud-ps-fmin",
                     "source" : "src/asmtest"
                 },
@@ -1758,7 +7410,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "254df67bb1e4ae17c381a6aa028ab217",
+                    "md5sum" : "1f16c41ab75c4d5284783e314758fc57",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ud-ps-ldst",
                     "source" : "src/asmtest"
                 },
@@ -1768,7 +7420,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "4bbd2e8d8929c0b5aa3984d4f07c9b7d",
+                    "md5sum" : "3e6ddcd1ca89b9c3eb69dfd22c068e33",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ud-ps-move",
                     "source" : "src/asmtest"
                 },
@@ -1778,7 +7430,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "110a26cf26a24a787759dfd95ca6b57e",
+                    "md5sum" : "4aedaee511564b115726d6857c3514f7",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ud-ps-recoding",
                     "source" : "src/asmtest"
                 },
@@ -1788,8 +7440,18 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "bfbd32687ce03667277b1aab264eaf0a",
+                    "md5sum" : "974c3f2fd4fcec0f46295bd0712a0308",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ud-ps-structural",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ud-p-structural",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "59df92f20e6122afd66f1bf15478ba41",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ud-p-structural",
                     "source" : "src/asmtest"
                 },
                 {
@@ -1798,7 +7460,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "b9163081289a8c6c54b9c01f94f11d03",
+                    "md5sum" : "29740d171138f99e4f2f37eaed8afe5c",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ud-v-fadd",
                     "source" : "src/asmtest"
                 },
@@ -1808,7 +7470,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "dce53c303671f09b5c01216cfe14a641",
+                    "md5sum" : "d4f54f31f232bef90aaecc827a240b9d",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ud-v-fclass",
                     "source" : "src/asmtest"
                 },
@@ -1818,7 +7480,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "3826335b0512b741305661eb57e86628",
+                    "md5sum" : "a6e5bc81678b4a544b07cb756735bf70",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ud-v-fcmp",
                     "source" : "src/asmtest"
                 },
@@ -1828,7 +7490,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "a6c4492502f5bb0f983d152b7b6c535d",
+                    "md5sum" : "c1c9eac73d6cf7e1cc31a458aa38bc79",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ud-v-fcvt",
                     "source" : "src/asmtest"
                 },
@@ -1838,7 +7500,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "f2261cec4e1bf4d253ab18d27f32f119",
+                    "md5sum" : "bdeccb0b75f30f6b221724b0db90a9f9",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ud-v-fcvt_w",
                     "source" : "src/asmtest"
                 },
@@ -1848,7 +7510,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "0bf318396f5fc0bebf810eca1f959a20",
+                    "md5sum" : "859422cb2fc2d99ff13488468a5e3cea",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ud-v-fdiv",
                     "source" : "src/asmtest"
                 },
@@ -1858,7 +7520,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "e628460d478c3db8080e7faaa0fc5b22",
+                    "md5sum" : "2e76c98797f8d6c736a6fdec8f5c19af",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ud-v-fmadd",
                     "source" : "src/asmtest"
                 },
@@ -1868,7 +7530,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "9a738938d06df5ac12889e01c911f78d",
+                    "md5sum" : "b768290ea5cea1cfc1227057e13c87bd",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ud-v-fmin",
                     "source" : "src/asmtest"
                 },
@@ -1878,7 +7540,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "97b2d693e4a9f6ed21137f4c7d541685",
+                    "md5sum" : "dfada0946cea097017c574f68e35bb96",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ud-v-ldst",
                     "source" : "src/asmtest"
                 },
@@ -1888,7 +7550,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "4b758433d00da42338ddeaecc3e71e13",
+                    "md5sum" : "2dc1d51db9bf92447cec86e5895d21aa",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ud-v-move",
                     "source" : "src/asmtest"
                 },
@@ -1898,7 +7560,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "90dbc06d2f035deb55c9f03385d89908",
+                    "md5sum" : "ba16f139a74d9468ddc7044a7d1d4f21",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ud-v-recoding",
                     "source" : "src/asmtest"
                 },
@@ -1908,7 +7570,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "e79911f5564596d0e6fcf74126f82928",
+                    "md5sum" : "9c31d6f0fe979a8229d3566ba7b75573",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ud-v-structural",
                     "source" : "src/asmtest"
                 },
@@ -1918,7 +7580,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "b72484f7b3acf248a0bb3b95dd2952e5",
+                    "md5sum" : "8e1a947f999d30f7fe408fefb3666d96",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64uf-p-fadd",
                     "source" : "src/asmtest"
                 },
@@ -1928,7 +7590,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "abc897ae9c8008ec62b4d487dc949bcd",
+                    "md5sum" : "11e11e84fc73953201a28378c0b039f7",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64uf-p-fclass",
                     "source" : "src/asmtest"
                 },
@@ -1938,7 +7600,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "d9d51339aaa8901bff0514d7b2d926b5",
+                    "md5sum" : "bee1f887cd37ee12fdf10f29528e346a",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64uf-p-fcmp",
                     "source" : "src/asmtest"
                 },
@@ -1948,7 +7610,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "55461ce28b5f6d92dc6883e989493705",
+                    "md5sum" : "3d1e7f6de01609f51edd82fe91b869fd",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64uf-p-fcvt",
                     "source" : "src/asmtest"
                 },
@@ -1958,7 +7620,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "54cf9f4b8b899881ddc9b07f8b980866",
+                    "md5sum" : "b280722822672fd2f7b67c86f505831c",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64uf-p-fcvt_w",
                     "source" : "src/asmtest"
                 },
@@ -1968,7 +7630,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "ecaabb4034c268fd73995f25570c7e8b",
+                    "md5sum" : "e5a53a011dc907cfb024306cb0ea230f",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64uf-p-fdiv",
                     "source" : "src/asmtest"
                 },
@@ -1978,7 +7640,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "89aaaa9e8ab9d822f384c3f3543d304d",
+                    "md5sum" : "37b3f3828daf67fb75737b765562180b",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64uf-p-fmadd",
                     "source" : "src/asmtest"
                 },
@@ -1988,7 +7650,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "abd4b19567c4c3aa3cd312180251b914",
+                    "md5sum" : "3aff6c5bc31fcdd513c1433743ffc0ac",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64uf-p-fmin",
                     "source" : "src/asmtest"
                 },
@@ -1998,7 +7660,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "51590ab6fcb6975ddfca44a953d25ecb",
+                    "md5sum" : "413823f3f6ed0733043b392e056bc358",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64uf-p-ldst",
                     "source" : "src/asmtest"
                 },
@@ -2008,7 +7670,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "ff9b084b3f1e88ac8825a1726f1ac353",
+                    "md5sum" : "d0880d30e6fe95272d0af8afad7620f5",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64uf-p-move",
                     "source" : "src/asmtest"
                 },
@@ -2018,7 +7680,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "d9df1aecd763a903e93f09ebcb6ac516",
+                    "md5sum" : "71b035a7804f3df4ee75a81237dc35af",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64uf-p-recoding",
                     "source" : "src/asmtest"
                 },
@@ -2028,7 +7690,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "4fc255350e09958b7d1dac5c15d6a458",
+                    "md5sum" : "48dfbec77e6a62d93f476dd42de4a7dc",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64uf-ps-fadd",
                     "source" : "src/asmtest"
                 },
@@ -2038,7 +7700,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "c779cb1efab84f59776d8c49f11b891d",
+                    "md5sum" : "1b570ad726c7e1af55da890b334702ae",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64uf-ps-fclass",
                     "source" : "src/asmtest"
                 },
@@ -2048,7 +7710,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "d1b1e98a9cc071d68c037f21b1a6b515",
+                    "md5sum" : "f8d955d13da96c3c29eefb59d28b5f76",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64uf-ps-fcmp",
                     "source" : "src/asmtest"
                 },
@@ -2058,7 +7720,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "0c8d0365a7364f90fde48da56f8d17a0",
+                    "md5sum" : "040f0bdc27d61b8aaf0a82624c52c9cc",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64uf-ps-fcvt",
                     "source" : "src/asmtest"
                 },
@@ -2068,7 +7730,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "9500c44421227806e1167c5ff63fc25e",
+                    "md5sum" : "52c52f4368dc7419c348721c4fc4b6c3",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64uf-ps-fcvt_w",
                     "source" : "src/asmtest"
                 },
@@ -2078,7 +7740,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "3feb667478a073a4383987161ed1b3f5",
+                    "md5sum" : "8c885f9624a81572569fe0a4dc019f69",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64uf-ps-fdiv",
                     "source" : "src/asmtest"
                 },
@@ -2088,7 +7750,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "b6684ec8e959dc350941d99188a4576f",
+                    "md5sum" : "f2918b5e568d00fe4cb40868bf9e68f7",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64uf-ps-fmadd",
                     "source" : "src/asmtest"
                 },
@@ -2098,7 +7760,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "d7f7ca68f9b842c4df23170fcec42c8c",
+                    "md5sum" : "5d7873d9994576de3c651a82eddfd28e",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64uf-ps-fmin",
                     "source" : "src/asmtest"
                 },
@@ -2108,7 +7770,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "610fd5f2585be41fe2c6c7f14ef6874c",
+                    "md5sum" : "768e36603a2a8573019aeb20da9eb9a3",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64uf-ps-ldst",
                     "source" : "src/asmtest"
                 },
@@ -2118,7 +7780,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "49c3b074e112f3736ed2dd9aa60ead5d",
+                    "md5sum" : "d2b0258566f894c5c65590734a61c911",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64uf-ps-move",
                     "source" : "src/asmtest"
                 },
@@ -2128,7 +7790,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "c3eb1450641d33083592fccb458f7054",
+                    "md5sum" : "5fd322acc9ca4f66bee7f77ab103e82a",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64uf-ps-recoding",
                     "source" : "src/asmtest"
                 },
@@ -2138,7 +7800,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "5960892db8d92369fee8906f811c2b7e",
+                    "md5sum" : "04bc9dff7f244d0ddd85298505167bb1",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64uf-v-fadd",
                     "source" : "src/asmtest"
                 },
@@ -2148,7 +7810,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "1e481a47ee5dde3cafafd811f26de687",
+                    "md5sum" : "41d405c5282feb90682e327f222bc3b6",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64uf-v-fclass",
                     "source" : "src/asmtest"
                 },
@@ -2158,7 +7820,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "0c1c49e5fa9d3c4710eb1aa8799ebe7d",
+                    "md5sum" : "83d5f089eb8780fd36a92d7fae43eab3",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64uf-v-fcmp",
                     "source" : "src/asmtest"
                 },
@@ -2168,7 +7830,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "e355d5f88669f1eab54fdbb7a66cfbc1",
+                    "md5sum" : "62c2b4ddf2fc75a12296f4348ebfbce2",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64uf-v-fcvt",
                     "source" : "src/asmtest"
                 },
@@ -2178,7 +7840,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "52e6bcfcd0fc671126f4f93277fdb33b",
+                    "md5sum" : "893f14b5db2f96b0c6fb067f3771f60b",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64uf-v-fcvt_w",
                     "source" : "src/asmtest"
                 },
@@ -2188,7 +7850,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "585f6f7ff1426432841566996c8b1e86",
+                    "md5sum" : "491576b3d88b7e2eb96c9f77fc873469",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64uf-v-fdiv",
                     "source" : "src/asmtest"
                 },
@@ -2198,7 +7860,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "a771e99476fe60661f70d2c38d482b59",
+                    "md5sum" : "39205c359e582816f8c5542626ba8106",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64uf-v-fmadd",
                     "source" : "src/asmtest"
                 },
@@ -2208,7 +7870,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "4277c4a3a15154418440f8b667fb5897",
+                    "md5sum" : "92b3675d822edc6d36dcffc8bbb88e9c",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64uf-v-fmin",
                     "source" : "src/asmtest"
                 },
@@ -2218,7 +7880,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "93ecdee8e10bad66a9dc87b4f0bd6abf",
+                    "md5sum" : "f011fb7335ef0634b8c41a3fe3ddd793",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64uf-v-ldst",
                     "source" : "src/asmtest"
                 },
@@ -2228,7 +7890,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "fab0d3008a72e65a8cda7b53bb2b4ef3",
+                    "md5sum" : "0c319f3020cfd4a2b38a2869f2783561",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64uf-v-move",
                     "source" : "src/asmtest"
                 },
@@ -2238,7 +7900,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "93010be0f7532720e52b5c42e66cec4c",
+                    "md5sum" : "c8b701669cccd3609503aca961ae531b",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64uf-v-recoding",
                     "source" : "src/asmtest"
                 },
@@ -2248,7 +7910,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "5ae1f4792f8ac4a4fd81f86244852429",
+                    "md5sum" : "74e77dfdf1f039e0bcfd620bc89056f1",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-p-add",
                     "source" : "src/asmtest"
                 },
@@ -2258,7 +7920,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "f8ddfbd3eaf80ffe9f3ef962ce2fa3dc",
+                    "md5sum" : "e84f9e5c2f9f674d2b2a8629178fe020",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-p-addi",
                     "source" : "src/asmtest"
                 },
@@ -2268,7 +7930,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "811df894399a88791205bed13af760df",
+                    "md5sum" : "f071e3967c5ebc5692535680870e0f64",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-p-addiw",
                     "source" : "src/asmtest"
                 },
@@ -2278,7 +7940,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "5859a793f0c9ceea435d775acf9a809d",
+                    "md5sum" : "68b5c0c715bac4b0615446634eb1c3c5",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-p-addw",
                     "source" : "src/asmtest"
                 },
@@ -2288,7 +7950,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "12c4f4a5d89fc1f8559176f58bba7fbc",
+                    "md5sum" : "618f2253594202954d29627b461865b1",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-p-and",
                     "source" : "src/asmtest"
                 },
@@ -2298,7 +7960,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "d77d7713c2db6a4b4cde3f5635c0656a",
+                    "md5sum" : "cdab5c1bc086139c0e91a5686941206f",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-p-andi",
                     "source" : "src/asmtest"
                 },
@@ -2308,7 +7970,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "08aefe8b537ba936dd9b6e1847efdda5",
+                    "md5sum" : "8b449d9b86c6cf720519006ee57496fe",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-p-auipc",
                     "source" : "src/asmtest"
                 },
@@ -2318,7 +7980,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "34e3d014b15327200ae358288311449f",
+                    "md5sum" : "c3822f9d29f6bf9a2bfb0e79b626fe91",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-p-beq",
                     "source" : "src/asmtest"
                 },
@@ -2328,7 +7990,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "e3bde7e1a401b690f4aac83e27faf06d",
+                    "md5sum" : "7b55544c985f2d4cdc7f82b9fa6fb740",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-p-bge",
                     "source" : "src/asmtest"
                 },
@@ -2338,7 +8000,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "ce6e5c09f53074fb47ec9e138c839856",
+                    "md5sum" : "c3826264222a17dcb0c09c0c751e1308",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-p-bgeu",
                     "source" : "src/asmtest"
                 },
@@ -2348,7 +8010,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "a40194025841ef4a97d75788f27e8901",
+                    "md5sum" : "0e71ded5b84149e3caf9fbd08d477bfd",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-p-blt",
                     "source" : "src/asmtest"
                 },
@@ -2358,7 +8020,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "9770c269235de402e047c2d77f317a00",
+                    "md5sum" : "957afe8a6e81fc5ad473cfc59002c9c0",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-p-bltu",
                     "source" : "src/asmtest"
                 },
@@ -2368,7 +8030,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "8ecaadbc6f50336d3001993f6076da6d",
+                    "md5sum" : "8c5391ee49cf2fdb18ba92950fac0f1b",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-p-bne",
                     "source" : "src/asmtest"
                 },
@@ -2378,7 +8040,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "6c68ee9ca88db3491d9964fb8fbb292e",
+                    "md5sum" : "364c6ea86b54ea8d2780339091ab009d",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-p-fence_i",
                     "source" : "src/asmtest"
                 },
@@ -2388,7 +8050,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "d0c4593786e20835f21854187aab5336",
+                    "md5sum" : "c0ebc191259a4506bca5dfa11377b20e",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-p-jal",
                     "source" : "src/asmtest"
                 },
@@ -2398,7 +8060,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "8f7b5ae0fb06339646d442faeb3d2112",
+                    "md5sum" : "029fdacb3ea257cb5c191655873e3da9",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-p-jalr",
                     "source" : "src/asmtest"
                 },
@@ -2408,7 +8070,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "410b4b665b2700bfc7de8ca2bee13eba",
+                    "md5sum" : "05cd746dcbf4c58a46b491be2715ebd6",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-p-lb",
                     "source" : "src/asmtest"
                 },
@@ -2418,7 +8080,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "b2a8b33f9ef795c61b20ad609e8d4f68",
+                    "md5sum" : "9e33b73729293b53388467824bea776a",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-p-lbu",
                     "source" : "src/asmtest"
                 },
@@ -2428,7 +8090,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "cfbbf197c28734913b82af86acb8c6b6",
+                    "md5sum" : "fe724c575ae422aacc9885f1adbc4ebe",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-p-ld",
                     "source" : "src/asmtest"
                 },
@@ -2438,7 +8100,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "b27b4d2c93df265c40dd775db91a51d4",
+                    "md5sum" : "874730d9be66d1e0fd4911209bb4ee9c",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-p-lh",
                     "source" : "src/asmtest"
                 },
@@ -2448,7 +8110,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "0191f964bb5943bc5190d053889bfe58",
+                    "md5sum" : "b8aee39f0e90d2961d4f0f40e777432c",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-p-lhu",
                     "source" : "src/asmtest"
                 },
@@ -2458,7 +8120,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "8710ceb57d6270e93036c17078d98d7c",
+                    "md5sum" : "a994f27699aae0d9adc95f9d72a98c83",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-p-lui",
                     "source" : "src/asmtest"
                 },
@@ -2468,7 +8130,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "dfcbdaea89a69181574935fa06480d19",
+                    "md5sum" : "c92f7678541e4e8934342a9ca79b9df2",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-p-lw",
                     "source" : "src/asmtest"
                 },
@@ -2478,7 +8140,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "d69dc6ea165ec6c9214b712e15a1d8ab",
+                    "md5sum" : "0cc2b60ff897d16685831f9ec0595cb5",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-p-lwu",
                     "source" : "src/asmtest"
                 },
@@ -2488,7 +8150,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "45482709f8564d4ba4b9906233b9bb7b",
+                    "md5sum" : "a7ec2716513f2ce1fa51869845bfdee2",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-p-or",
                     "source" : "src/asmtest"
                 },
@@ -2498,258 +8160,8 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "3c041292f2c31baa227c2e54975220fe",
+                    "md5sum" : "45d6313057af95b0189c34ebdf3f5a7d",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-p-ori",
-                    "source" : "src/asmtest"
-                },
-                {
-                    "type" : "resource",
-                    "name" : "rv64ui-p-sb",
-                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
-                    "architecture" : "RISCV",
-                    "is_zipped" : false,
-                    "md5sum" : "1cd1d04fca58d003ce28b65d92aa8889",
-                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-p-sb",
-                    "source" : "src/asmtest"
-                },
-                {
-                    "type" : "resource",
-                    "name" : "rv64ui-p-sd",
-                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
-                    "architecture" : "RISCV",
-                    "is_zipped" : false,
-                    "md5sum" : "c13a92bdf9d9faf4d991cbd4082b9166",
-                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-p-sd",
-                    "source" : "src/asmtest"
-                },
-                {
-                    "type" : "resource",
-                    "name" : "rv64ui-p-sh",
-                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
-                    "architecture" : "RISCV",
-                    "is_zipped" : false,
-                    "md5sum" : "6741dde915fdb1fd7f8bb4ac7852158d",
-                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-p-sh",
-                    "source" : "src/asmtest"
-                },
-                {
-                    "type" : "resource",
-                    "name" : "rv64ui-p-simple",
-                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
-                    "architecture" : "RISCV",
-                    "is_zipped" : false,
-                    "md5sum" : "c036528d8a1f12baf7b546c9c43eac67",
-                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-p-simple",
-                    "source" : "src/asmtest"
-                },
-                {
-                    "type" : "resource",
-                    "name" : "rv64ui-p-sll",
-                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
-                    "architecture" : "RISCV",
-                    "is_zipped" : false,
-                    "md5sum" : "afaf75edf394431f0541421fdedef154",
-                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-p-sll",
-                    "source" : "src/asmtest"
-                },
-                {
-                    "type" : "resource",
-                    "name" : "rv64ui-p-slli",
-                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
-                    "architecture" : "RISCV",
-                    "is_zipped" : false,
-                    "md5sum" : "d9b824f13fe53593069279b587f0fd21",
-                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-p-slli",
-                    "source" : "src/asmtest"
-                },
-                {
-                    "type" : "resource",
-                    "name" : "rv64ui-p-slliw",
-                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
-                    "architecture" : "RISCV",
-                    "is_zipped" : false,
-                    "md5sum" : "0483c28d9120c85221da62919075fe8e",
-                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-p-slliw",
-                    "source" : "src/asmtest"
-                },
-                {
-                    "type" : "resource",
-                    "name" : "rv64ui-p-sllw",
-                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
-                    "architecture" : "RISCV",
-                    "is_zipped" : false,
-                    "md5sum" : "0d3f4747b0046b58b2ba155d20405fae",
-                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-p-sllw",
-                    "source" : "src/asmtest"
-                },
-                {
-                    "type" : "resource",
-                    "name" : "rv64ui-p-slt",
-                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
-                    "architecture" : "RISCV",
-                    "is_zipped" : false,
-                    "md5sum" : "b14b9dec4e19c6548d8e73a81c82fef3",
-                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-p-slt",
-                    "source" : "src/asmtest"
-                },
-                {
-                    "type" : "resource",
-                    "name" : "rv64ui-p-slti",
-                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
-                    "architecture" : "RISCV",
-                    "is_zipped" : false,
-                    "md5sum" : "9d161594c5ae5b1636d2ebc981d2a45e",
-                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-p-slti",
-                    "source" : "src/asmtest"
-                },
-                {
-                    "type" : "resource",
-                    "name" : "rv64ui-p-sltiu",
-                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
-                    "architecture" : "RISCV",
-                    "is_zipped" : false,
-                    "md5sum" : "6a8625e73078e75b778213565c7631dc",
-                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-p-sltiu",
-                    "source" : "src/asmtest"
-                },
-                {
-                    "type" : "resource",
-                    "name" : "rv64ui-p-sltu",
-                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
-                    "architecture" : "RISCV",
-                    "is_zipped" : false,
-                    "md5sum" : "31ec3d8b7d4765ef07deb50d79d38ed0",
-                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-p-sltu",
-                    "source" : "src/asmtest"
-                },
-                {
-                    "type" : "resource",
-                    "name" : "rv64ui-p-sra",
-                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
-                    "architecture" : "RISCV",
-                    "is_zipped" : false,
-                    "md5sum" : "7d956b7c764493886357194f5dbc476e",
-                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-p-sra",
-                    "source" : "src/asmtest"
-                },
-                {
-                    "type" : "resource",
-                    "name" : "rv64ui-p-srai",
-                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
-                    "architecture" : "RISCV",
-                    "is_zipped" : false,
-                    "md5sum" : "cd631b57809962e3237726aa159673c8",
-                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-p-srai",
-                    "source" : "src/asmtest"
-                },
-                {
-                    "type" : "resource",
-                    "name" : "rv64ui-p-sraiw",
-                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
-                    "architecture" : "RISCV",
-                    "is_zipped" : false,
-                    "md5sum" : "b61112cc7c6d550393660b872fb3f064",
-                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-p-sraiw",
-                    "source" : "src/asmtest"
-                },
-                {
-                    "type" : "resource",
-                    "name" : "rv64ui-p-sraw",
-                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
-                    "architecture" : "RISCV",
-                    "is_zipped" : false,
-                    "md5sum" : "d3c5aaa6c67ee3e423548f78c1e114ea",
-                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-p-sraw",
-                    "source" : "src/asmtest"
-                },
-                {
-                    "type" : "resource",
-                    "name" : "rv64ui-p-srl",
-                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
-                    "architecture" : "RISCV",
-                    "is_zipped" : false,
-                    "md5sum" : "ed342633350a369977683b069bee7d3a",
-                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-p-srl",
-                    "source" : "src/asmtest"
-                },
-                {
-                    "type" : "resource",
-                    "name" : "rv64ui-p-srli",
-                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
-                    "architecture" : "RISCV",
-                    "is_zipped" : false,
-                    "md5sum" : "da4399a1da3b5caf218ed4950e96762b",
-                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-p-srli",
-                    "source" : "src/asmtest"
-                },
-                {
-                    "type" : "resource",
-                    "name" : "rv64ui-p-srliw",
-                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
-                    "architecture" : "RISCV",
-                    "is_zipped" : false,
-                    "md5sum" : "85d33d6b905527fd99afc52979eb1612",
-                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-p-srliw",
-                    "source" : "src/asmtest"
-                },
-                {
-                    "type" : "resource",
-                    "name" : "rv64ui-p-srlw",
-                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
-                    "architecture" : "RISCV",
-                    "is_zipped" : false,
-                    "md5sum" : "3977283582e73e51cd67f828b2ee2315",
-                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-p-srlw",
-                    "source" : "src/asmtest"
-                },
-                {
-                    "type" : "resource",
-                    "name" : "rv64ui-p-sub",
-                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
-                    "architecture" : "RISCV",
-                    "is_zipped" : false,
-                    "md5sum" : "592f8add96467450a7de320221d86d76",
-                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-p-sub",
-                    "source" : "src/asmtest"
-                },
-                {
-                    "type" : "resource",
-                    "name" : "rv64ui-p-subw",
-                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
-                    "architecture" : "RISCV",
-                    "is_zipped" : false,
-                    "md5sum" : "8994d07e1f5b91610d95049cdf8287a9",
-                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-p-subw",
-                    "source" : "src/asmtest"
-                },
-                {
-                    "type" : "resource",
-                    "name" : "rv64ui-p-sw",
-                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
-                    "architecture" : "RISCV",
-                    "is_zipped" : false,
-                    "md5sum" : "f61fa9d97a70fafcc77eeac8dae36484",
-                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-p-sw",
-                    "source" : "src/asmtest"
-                },
-                {
-                    "type" : "resource",
-                    "name" : "rv64ui-p-xor",
-                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
-                    "architecture" : "RISCV",
-                    "is_zipped" : false,
-                    "md5sum" : "594712c1b8c74b5b087bac30246e9364",
-                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-p-xor",
-                    "source" : "src/asmtest"
-                },
-                {
-                    "type" : "resource",
-                    "name" : "rv64ui-p-xori",
-                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
-                    "architecture" : "RISCV",
-                    "is_zipped" : false,
-                    "md5sum" : "19cc10117d97e3fbb41e2d2786f79198",
-                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-p-xori",
                     "source" : "src/asmtest"
                 },
                 {
@@ -2758,7 +8170,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "13b6948da6a2357bcdcd829b56e84bd1",
+                    "md5sum" : "25b954ad7bae86ef76c794d8db1fc5b3",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-ps-add",
                     "source" : "src/asmtest"
                 },
@@ -2768,7 +8180,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "6dfbf697061615476057e460c9f62b3d",
+                    "md5sum" : "7464157d975270c6bd9e121e103dba18",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-ps-addi",
                     "source" : "src/asmtest"
                 },
@@ -2778,7 +8190,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "015db9a17305885bd5907ab9d3fa91dc",
+                    "md5sum" : "570c68f2657877b4caeee1d1d6e054ea",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-ps-addiw",
                     "source" : "src/asmtest"
                 },
@@ -2788,7 +8200,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "a77aadcebc1f3d5cf4526dee37c90510",
+                    "md5sum" : "346024c155bacc1f9ce5449f201aaac7",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-ps-addw",
                     "source" : "src/asmtest"
                 },
@@ -2798,7 +8210,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "088d34a01ff842d44b5a4db607e549c4",
+                    "md5sum" : "baca0bba2f1e7c2eeb9af4b63dc9965f",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-ps-and",
                     "source" : "src/asmtest"
                 },
@@ -2808,7 +8220,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "ddde8986ae4e4fd87c4bf4b16b2544aa",
+                    "md5sum" : "0ffd0ea3e33504c285ffa8108673b536",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-ps-andi",
                     "source" : "src/asmtest"
                 },
@@ -2818,8 +8230,18 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "1a4847e8ec5d826eea60f709d95dac97",
+                    "md5sum" : "febca98775bb2ffc6944cc9c2ffc1e4a",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-ps-auipc",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ui-p-sb",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "d726a3ff57b30b97d160cfe42a491947",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-p-sb",
                     "source" : "src/asmtest"
                 },
                 {
@@ -2828,7 +8250,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "0434433ea79b6cc44c001a161babbd67",
+                    "md5sum" : "0dfdabe82a1e04ff697ade1b1bffa41e",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-ps-beq",
                     "source" : "src/asmtest"
                 },
@@ -2838,7 +8260,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "fa822964f28d847ff7b1d69a1ee6aa7c",
+                    "md5sum" : "9571a68a266f6139dc5e740b920abebd",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-ps-bge",
                     "source" : "src/asmtest"
                 },
@@ -2848,7 +8270,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "c9680e0e6081fc0d6f0369c563165228",
+                    "md5sum" : "c304075a35eb1cf5fc07d9cfd28b2854",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-ps-bgeu",
                     "source" : "src/asmtest"
                 },
@@ -2858,7 +8280,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "f224e7e7ff0e6975d9ced89f4b78a62a",
+                    "md5sum" : "4785e7702470f926696704d8fc5ad22a",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-ps-blt",
                     "source" : "src/asmtest"
                 },
@@ -2868,7 +8290,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "842078af75769453b2df67c5c28babb3",
+                    "md5sum" : "72f1503f6b717740ab8cc04d9f6e405c",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-ps-bltu",
                     "source" : "src/asmtest"
                 },
@@ -2878,8 +8300,18 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "6cf9760f0307b15b2ddcb317017e8087",
+                    "md5sum" : "f86a43621010d8c3263f139e1b5f60cc",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-ps-bne",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ui-p-sd",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "e6709d369f5ca6d676a5e1b3fd216841",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-p-sd",
                     "source" : "src/asmtest"
                 },
                 {
@@ -2888,8 +8320,28 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "78d9408139d005819a58802aa6a20e7e",
+                    "md5sum" : "795d83a181110eb15e4266a022295fea",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-ps-fence_i",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ui-p-sh",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "6c4e8630b321c454ca96ac3dd573f5cd",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-p-sh",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ui-p-simple",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "fe3e89e1cb50df7164475e700c1d0409",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-p-simple",
                     "source" : "src/asmtest"
                 },
                 {
@@ -2898,7 +8350,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "30f8d2b4a754b1c0db615aa53f4204aa",
+                    "md5sum" : "162220f7d76eebd2e0eb6d755710850e",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-ps-jal",
                     "source" : "src/asmtest"
                 },
@@ -2908,7 +8360,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "656ba873c7261240d0bcc393a99644fa",
+                    "md5sum" : "4fd3a43037b3f618772ce8f46ff14fae",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-ps-jalr",
                     "source" : "src/asmtest"
                 },
@@ -2918,7 +8370,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "af983b6499aa6b1aa8f48625b28122fa",
+                    "md5sum" : "cf7bce9618630b3837387502f793a5aa",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-ps-lb",
                     "source" : "src/asmtest"
                 },
@@ -2928,7 +8380,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "b862e0d36be2780fc2208853419208fa",
+                    "md5sum" : "0f668f995cc45a019a92ceb36ccda771",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-ps-lbu",
                     "source" : "src/asmtest"
                 },
@@ -2938,7 +8390,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "27cfd2226a88a83ec00a5f28e71f2591",
+                    "md5sum" : "3f283538839bc712329be9e7b73a46ae",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-ps-ld",
                     "source" : "src/asmtest"
                 },
@@ -2948,7 +8400,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "e5de1e7f4798765fc25c5279fac8d1c4",
+                    "md5sum" : "bde993ba535be57499f1e86f1850b4ed",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-ps-lh",
                     "source" : "src/asmtest"
                 },
@@ -2958,8 +8410,88 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "4afe6afdc5320dd45e7080396f7378c4",
+                    "md5sum" : "e0d69c1be3ffc16ae54ea8c3bcfd2bcf",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-ps-lhu",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ui-p-sll",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "e27b9e9a6e8c425375fc096cc8ffa2ab",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-p-sll",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ui-p-slli",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "72e477249f595f9c8628d6c48a0ffee4",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-p-slli",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ui-p-slliw",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "a475ca95ae0a8a2c4b22af1f6a0ac04a",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-p-slliw",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ui-p-sllw",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "06a6afdd702bb8e3f8fd658ca6ad2190",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-p-sllw",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ui-p-slt",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "3a691f903abc4efec03ddf6b115f2cd5",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-p-slt",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ui-p-slti",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "4443ffd1e5c9e7e8361ff226afc839b9",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-p-slti",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ui-p-sltiu",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "8142e61398ef8ff8e281b796957022d0",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-p-sltiu",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ui-p-sltu",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "eb9d27aa070b40a1361ac4ad7a75d329",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-p-sltu",
                     "source" : "src/asmtest"
                 },
                 {
@@ -2968,7 +8500,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "0fb63e51ca357783e8134e55d0d6fd95",
+                    "md5sum" : "9711be79e9acfc3bf1d96409c5174498",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-ps-lui",
                     "source" : "src/asmtest"
                 },
@@ -2978,7 +8510,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "52ff2024de2a0f9c6c422bb6e5f1d2a3",
+                    "md5sum" : "d38519f29721f81857b508cd91b60ac4",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-ps-lw",
                     "source" : "src/asmtest"
                 },
@@ -2988,7 +8520,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "ff71b5ac6e75680a90f825ba0cc78285",
+                    "md5sum" : "ce3de4b8ecac7cabfbf106cc3cb1aae4",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-ps-lwu",
                     "source" : "src/asmtest"
                 },
@@ -2998,7 +8530,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "878d822e9a8825327f060200403d19d9",
+                    "md5sum" : "602023fdace63e3095d1a90c0a24cd3b",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-ps-or",
                     "source" : "src/asmtest"
                 },
@@ -3008,8 +8540,88 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "69e92a5bfaff07667d904a5d4f26f47d",
+                    "md5sum" : "d5db17eb1a4fd8679803af4c71f7b8fd",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-ps-ori",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ui-p-sra",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "3fd883b27185c84bb9140911c9426a03",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-p-sra",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ui-p-srai",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "e2c522b314d7a6c118442410ad5ed227",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-p-srai",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ui-p-sraiw",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "22623d5cf7759b415e9db84a6df76f8f",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-p-sraiw",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ui-p-sraw",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "9aa501973cc7b119c7df9bd9456a72ec",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-p-sraw",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ui-p-srl",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "e731e0c32b317f4c0be8aa8977e11acc",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-p-srl",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ui-p-srli",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "e3f733fdee9b668ed24a367b3d4d9dbc",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-p-srli",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ui-p-srliw",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "39b13b58249e1eb6af259c714dc585b5",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-p-srliw",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ui-p-srlw",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "34e6966b88da3e84d313f5ab53a4f468",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-p-srlw",
                     "source" : "src/asmtest"
                 },
                 {
@@ -3018,7 +8630,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "48de8bb47f1d4f4c2b8d67ccac452c3d",
+                    "md5sum" : "b1d2a9be4fb5fdbbe3c3c4b78ece12b3",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-ps-sb",
                     "source" : "src/asmtest"
                 },
@@ -3028,7 +8640,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "cb1bb63deaa9da41714d9991553c2ef0",
+                    "md5sum" : "f4cd24c9b08a575a9d781d19f31a9bbf",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-ps-sd",
                     "source" : "src/asmtest"
                 },
@@ -3038,7 +8650,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "c912983af1c58176fb7d567be732c87d",
+                    "md5sum" : "fa55efb6b75235488ae9c5b375b1f3c1",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-ps-sh",
                     "source" : "src/asmtest"
                 },
@@ -3048,7 +8660,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "62b01468e7c4d324c0acc7536b0b7e0a",
+                    "md5sum" : "973dfc894bcd1bb22c2587c4904f644d",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-ps-simple",
                     "source" : "src/asmtest"
                 },
@@ -3058,7 +8670,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "283d19bdb002c986366ff270839cf15e",
+                    "md5sum" : "24f7f5387e365cb1f99d78a0cdc4039c",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-ps-sll",
                     "source" : "src/asmtest"
                 },
@@ -3068,7 +8680,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "50845da8fd5f57789c55e2b025f0e90f",
+                    "md5sum" : "1954091e71478b57ef7fa8a1f7ec4037",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-ps-slli",
                     "source" : "src/asmtest"
                 },
@@ -3078,7 +8690,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "006859a1917f83aa5a7f1eb2ba61421a",
+                    "md5sum" : "b0e3221411ce69d8b3ac6735ad8d7a8b",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-ps-slliw",
                     "source" : "src/asmtest"
                 },
@@ -3088,7 +8700,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "fa74956bc42617642cf56b17ce7b7b82",
+                    "md5sum" : "0b0279caa7acbd856a2d9f83bde37a1f",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-ps-sllw",
                     "source" : "src/asmtest"
                 },
@@ -3098,7 +8710,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "669aa8ae65e5614752b5994eb81f7de1",
+                    "md5sum" : "5ba622fcf4d17b629caaf0a3765645bc",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-ps-slt",
                     "source" : "src/asmtest"
                 },
@@ -3108,7 +8720,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "44d2269759e1b5fb2ab2d764060292fc",
+                    "md5sum" : "0ef0aba2b349a5412e73541634d67952",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-ps-slti",
                     "source" : "src/asmtest"
                 },
@@ -3118,7 +8730,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "3415858543b5742bc5184e0b3c993300",
+                    "md5sum" : "398b00408f4651d87f088819154b70de",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-ps-sltiu",
                     "source" : "src/asmtest"
                 },
@@ -3128,7 +8740,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "28cb31170ad9d6c504c29d8c29edd24f",
+                    "md5sum" : "bfd21b67da7b0062a1cde21c281e15f4",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-ps-sltu",
                     "source" : "src/asmtest"
                 },
@@ -3138,7 +8750,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "f109c193247e2fb8434ce4c332f0cb41",
+                    "md5sum" : "feebc27003f400d9c353547b7a72b34a",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-ps-sra",
                     "source" : "src/asmtest"
                 },
@@ -3148,7 +8760,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "36d6c4883d27d7f6e96fd67cbeecca45",
+                    "md5sum" : "7791639bc599fac1238bb24d34ee037e",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-ps-srai",
                     "source" : "src/asmtest"
                 },
@@ -3158,7 +8770,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "d8d62c3727e5176ede4ba3839dfcc9cb",
+                    "md5sum" : "9f940a767ffb99f93166fcb7cdeb9636",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-ps-sraiw",
                     "source" : "src/asmtest"
                 },
@@ -3168,7 +8780,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "cb56211febe89c3b634c9b1de5d5f3e6",
+                    "md5sum" : "f7dea60ef0cb386d77d27b5fca7847eb",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-ps-sraw",
                     "source" : "src/asmtest"
                 },
@@ -3178,7 +8790,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "981b412a0c1114c34dfdb66b8068af71",
+                    "md5sum" : "3204373d4bd3894908cdd3817b861a29",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-ps-srl",
                     "source" : "src/asmtest"
                 },
@@ -3188,7 +8800,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "4c64e4c765ba8d1cbe12541473fd1f70",
+                    "md5sum" : "70654e77dc0aac4aab75357cb3428c5f",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-ps-srli",
                     "source" : "src/asmtest"
                 },
@@ -3198,7 +8810,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "ed8bed99a31ef1434f8cc0eae36fb651",
+                    "md5sum" : "a0ba9c21c1efb8a4cf9a6bb0de3ae439",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-ps-srliw",
                     "source" : "src/asmtest"
                 },
@@ -3208,7 +8820,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "9ea198e8b3841fa717046342083b3db1",
+                    "md5sum" : "d918e45700810f73841af49fdc8609d1",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-ps-srlw",
                     "source" : "src/asmtest"
                 },
@@ -3218,7 +8830,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "d264dce065710136c1a8d351400f80df",
+                    "md5sum" : "5a0e51afe972c08b28f6424e21c7fb45",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-ps-sub",
                     "source" : "src/asmtest"
                 },
@@ -3228,7 +8840,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "9ed1d807c716c7802ee8151d03daf9db",
+                    "md5sum" : "0762019b85022742f5f2288cdf263a1b",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-ps-subw",
                     "source" : "src/asmtest"
                 },
@@ -3238,8 +8850,38 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "f1e06d50f81552c17df23cd4ee17825e",
+                    "md5sum" : "ed00398b9c94a65ff677152a6722f4f1",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-ps-sw",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ui-p-sub",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "f069c6e273defc3041f00786c3260bdc",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-p-sub",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ui-p-subw",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "4f71f8e73c5cc1a2755dc62712119ecd",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-p-subw",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ui-p-sw",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "55caca84c18c65b11a3611569c033174",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-p-sw",
                     "source" : "src/asmtest"
                 },
                 {
@@ -3248,7 +8890,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "82b4ec464f6970b1aeea47aac09355ee",
+                    "md5sum" : "ce296fcedf012517a19e7444a520baff",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-ps-xor",
                     "source" : "src/asmtest"
                 },
@@ -3258,8 +8900,28 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "06c59f7a2962d7b43fffbb4c9a74f34e",
+                    "md5sum" : "7dd443cdb4f17ddaab100b33aa8a1059",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-ps-xori",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ui-p-xor",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "f923f747eb8313edd22ae1add902da14",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-p-xor",
+                    "source" : "src/asmtest"
+                },
+                {
+                    "type" : "resource",
+                    "name" : "rv64ui-p-xori",
+                    "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
+                    "architecture" : "RISCV",
+                    "is_zipped" : false,
+                    "md5sum" : "1ac1c674a21fb780829efde09e4a44fe",
+                    "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-p-xori",
                     "source" : "src/asmtest"
                 },
                 {
@@ -3268,7 +8930,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "4ac53c865c9f93b7669e82ad445ad1c8",
+                    "md5sum" : "ce2c7644277e13ec32608b6b7f3dabb3",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-v-add",
                     "source" : "src/asmtest"
                 },
@@ -3278,7 +8940,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "a77b433e265327ae78581f03e4a0b2bc",
+                    "md5sum" : "b88e3eecd79d571fb8a5e491ad192536",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-v-addi",
                     "source" : "src/asmtest"
                 },
@@ -3288,7 +8950,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "3d289fb592df639eaffd4dc92516e3ce",
+                    "md5sum" : "cb8ed85947b334a7d0f084e4f7a1edd6",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-v-addiw",
                     "source" : "src/asmtest"
                 },
@@ -3298,7 +8960,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "1f9b805b62b7a261aff16d682c0f9dab",
+                    "md5sum" : "e0ffb9897bea030bf1e8f59618c444d8",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-v-addw",
                     "source" : "src/asmtest"
                 },
@@ -3308,7 +8970,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "c536e569ec53a006b0f68954b2ac19a5",
+                    "md5sum" : "1296bf740ce457bc4f6345b82852bd94",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-v-and",
                     "source" : "src/asmtest"
                 },
@@ -3318,7 +8980,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "4851b63d6bf0a09235351eba6c4d3c21",
+                    "md5sum" : "eeb8b021d1add7238aa948cfe7941d06",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-v-andi",
                     "source" : "src/asmtest"
                 },
@@ -3328,7 +8990,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "314b3d6e861457ff8292b6591ffd4f51",
+                    "md5sum" : "8e7254d9579713fec8503788ebc2d360",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-v-auipc",
                     "source" : "src/asmtest"
                 },
@@ -3338,7 +9000,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "6f9d00065f40ef22577d16c3a5b288f8",
+                    "md5sum" : "189ecafc92c84d676a497a1de7f3867d",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-v-beq",
                     "source" : "src/asmtest"
                 },
@@ -3348,7 +9010,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "feb48724a40b2a434331fc4562094b80",
+                    "md5sum" : "3bc335d38af2248638acb77c8ca79c3b",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-v-bge",
                     "source" : "src/asmtest"
                 },
@@ -3358,7 +9020,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "9a5c00386faf006204bdaaf5e04e5a2d",
+                    "md5sum" : "414a009748b0f54518822139b02c92d5",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-v-bgeu",
                     "source" : "src/asmtest"
                 },
@@ -3368,7 +9030,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "9346cee2df12e391250dba9f8407e668",
+                    "md5sum" : "308bb96a7e6744233a2b8e7ed3292eb4",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-v-blt",
                     "source" : "src/asmtest"
                 },
@@ -3378,7 +9040,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "5ea5c0cd054c998a4779b4f96550fbfd",
+                    "md5sum" : "f2a785ecccf484213afcdd2d847ea010",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-v-bltu",
                     "source" : "src/asmtest"
                 },
@@ -3388,7 +9050,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "4affbfe59c08c3c5df5e7c1aa2a575d3",
+                    "md5sum" : "502cc40fcdc283237d5ca2f79f0e3b58",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-v-bne",
                     "source" : "src/asmtest"
                 },
@@ -3398,7 +9060,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "8ca111c5153f595cdff1d0cbfb46d8d0",
+                    "md5sum" : "d1c7ce2ec6c62fa47e3f96db65b9531f",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-v-fence_i",
                     "source" : "src/asmtest"
                 },
@@ -3408,7 +9070,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "e53a4a6a608c32c3fc40220feffe74c4",
+                    "md5sum" : "5b1ac87693239a5fd0aa956b8708a8b2",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-v-jal",
                     "source" : "src/asmtest"
                 },
@@ -3418,7 +9080,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "a8883869a4cca9a62993eab586bf9983",
+                    "md5sum" : "ac409582549fe2c526bd343e11acae9a",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-v-jalr",
                     "source" : "src/asmtest"
                 },
@@ -3428,7 +9090,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "b5ba6b4fe284446443e14a469a4201e9",
+                    "md5sum" : "973d448bd470008630ea3f15430ef831",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-v-lb",
                     "source" : "src/asmtest"
                 },
@@ -3438,7 +9100,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "d58a68b36b10f4b360e3b49890d8f747",
+                    "md5sum" : "bb5baa03932e9249ea6c15ec909d7288",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-v-lbu",
                     "source" : "src/asmtest"
                 },
@@ -3448,7 +9110,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "5106dc8f1c6fca7f05a592462ec26025",
+                    "md5sum" : "058c180b002f386b0e10ff2ab3de6e0b",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-v-ld",
                     "source" : "src/asmtest"
                 },
@@ -3458,7 +9120,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "c745aebb75f4789ad7a944b326cc98bc",
+                    "md5sum" : "f4051e80d7ace44bfa892e2f418baa6d",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-v-lh",
                     "source" : "src/asmtest"
                 },
@@ -3468,7 +9130,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "95ca302d8064d31d5e7f675ede76e5d2",
+                    "md5sum" : "b2bb7503ef9ffa80b432e062d1f9803c",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-v-lhu",
                     "source" : "src/asmtest"
                 },
@@ -3478,7 +9140,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "d91f414651ab5d6820f327c6a0283f3e",
+                    "md5sum" : "14f3721e4b6d61555702850b03ff0dbd",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-v-lui",
                     "source" : "src/asmtest"
                 },
@@ -3488,7 +9150,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "75218650a406049dd98d8b563e75dd29",
+                    "md5sum" : "6749b5439d82b9b5201cb062025935f7",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-v-lw",
                     "source" : "src/asmtest"
                 },
@@ -3498,7 +9160,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "65825081f96f22844a326a6d6790b755",
+                    "md5sum" : "09eb097c86f80becf10347b3b78fbe50",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-v-lwu",
                     "source" : "src/asmtest"
                 },
@@ -3508,7 +9170,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "bcf7ec774ba67868de996c94ffb28a8e",
+                    "md5sum" : "efc9b1b5bc2ffdf3754a1e28f0e17b21",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-v-or",
                     "source" : "src/asmtest"
                 },
@@ -3518,7 +9180,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "9ab3eea49545d31068a6f52a3893a4d6",
+                    "md5sum" : "f41a743d43b71b1f82f5539bcd43b9bb",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-v-ori",
                     "source" : "src/asmtest"
                 },
@@ -3528,7 +9190,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "6ee42880b6c060d2f7bcc217564f6450",
+                    "md5sum" : "3a2eb9bbe1d1e157fc68fcbdab29272b",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-v-sb",
                     "source" : "src/asmtest"
                 },
@@ -3538,7 +9200,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "676720cb24ac2adaee6ed0ec7ea27ccf",
+                    "md5sum" : "5318251f7f76d5b3e4e331d003767573",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-v-sd",
                     "source" : "src/asmtest"
                 },
@@ -3548,7 +9210,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "82aca94c8969bd2f8ea7ca9be7fbc8f2",
+                    "md5sum" : "7ffac9a169bc1db97c4120150ee77712",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-v-sh",
                     "source" : "src/asmtest"
                 },
@@ -3558,7 +9220,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "b26c36216ac9b248a4434950d2c61a8e",
+                    "md5sum" : "22f8c91940818b0b2e21146dab723ad4",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-v-simple",
                     "source" : "src/asmtest"
                 },
@@ -3568,7 +9230,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "c328191502ac82baa27d920991349234",
+                    "md5sum" : "b8c6294818c1a2dcb9730add7f466595",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-v-sll",
                     "source" : "src/asmtest"
                 },
@@ -3578,7 +9240,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "258c49788d40ce7ff5fc7459ed0d8c76",
+                    "md5sum" : "fdb2c93e9281daf53e54764dfebbd909",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-v-slli",
                     "source" : "src/asmtest"
                 },
@@ -3588,7 +9250,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "da8198692b96d46cfd2316590aa700de",
+                    "md5sum" : "e690e4af815dd72d29dc77b25e0c15a2",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-v-slliw",
                     "source" : "src/asmtest"
                 },
@@ -3598,7 +9260,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "e8546fe87f70356c61be6c570e38b994",
+                    "md5sum" : "979b68000cca35f5883752c91c820b6f",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-v-sllw",
                     "source" : "src/asmtest"
                 },
@@ -3608,7 +9270,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "5d4cd4d048577413992ad2f00204bc50",
+                    "md5sum" : "fd2da53c1bfe2ab70165b8d3d22d58eb",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-v-slt",
                     "source" : "src/asmtest"
                 },
@@ -3618,7 +9280,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "3ec767139c3603c9a610f29f1890e7a6",
+                    "md5sum" : "a3753bcfa5b42edeb82ade788f2e7c3e",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-v-slti",
                     "source" : "src/asmtest"
                 },
@@ -3628,7 +9290,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "17a4044b1ee6dd205a5e38752c4ce319",
+                    "md5sum" : "1b3b5227a6ccd64e93b755dc53e0387f",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-v-sltiu",
                     "source" : "src/asmtest"
                 },
@@ -3638,7 +9300,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "0995455fe6716d8b64c3273661702164",
+                    "md5sum" : "0968f85b1b4021ba32480688e21dedd2",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-v-sltu",
                     "source" : "src/asmtest"
                 },
@@ -3648,7 +9310,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "c6f8bf8fe35d6e972ef5010894462893",
+                    "md5sum" : "603c8f86e044394f9a6cfc64bbc9957f",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-v-sra",
                     "source" : "src/asmtest"
                 },
@@ -3658,7 +9320,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "f4cf327543b4a02ff3d2fc9164dc8c3f",
+                    "md5sum" : "f1a16a0f477785b55c8b3f0b57144f03",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-v-srai",
                     "source" : "src/asmtest"
                 },
@@ -3668,7 +9330,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "3115a0db99d8ca24af002f0375fa3336",
+                    "md5sum" : "b21039be0583412370d0c2ce77e3e198",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-v-sraiw",
                     "source" : "src/asmtest"
                 },
@@ -3678,7 +9340,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "8cff4bf8c7c2d834f5a4b10e2f7571f3",
+                    "md5sum" : "cca410523eea5722c294031ab335fb29",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-v-sraw",
                     "source" : "src/asmtest"
                 },
@@ -3688,7 +9350,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "f0a51bfd1ba6510f331d7c677af7ae74",
+                    "md5sum" : "15eff67a62d69968239115cda3e110fd",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-v-srl",
                     "source" : "src/asmtest"
                 },
@@ -3698,7 +9360,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "956f9fe8fdf55dfde2387334d3c57ce0",
+                    "md5sum" : "8aab6af90d2e833d8a35f02df7759f2c",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-v-srli",
                     "source" : "src/asmtest"
                 },
@@ -3708,7 +9370,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "b0c31b43c2ce91b3c296122785f0c1fc",
+                    "md5sum" : "862458331dd6f499b3d40939b7992d79",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-v-srliw",
                     "source" : "src/asmtest"
                 },
@@ -3718,7 +9380,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "cac0b3d218e978e90d981259098152ed",
+                    "md5sum" : "4211a37547af6ddeda7a3bb2cebc0145",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-v-srlw",
                     "source" : "src/asmtest"
                 },
@@ -3728,7 +9390,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "12998e74b2b9f66ac1889de77158f553",
+                    "md5sum" : "779aabbcc27cf60fb7970e5b1366c98c",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-v-sub",
                     "source" : "src/asmtest"
                 },
@@ -3738,7 +9400,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "c14f2da36dd956c663e8b8d504ef87d3",
+                    "md5sum" : "0b0ff7e4894c2646347b0ac501390ad4",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-v-subw",
                     "source" : "src/asmtest"
                 },
@@ -3748,7 +9410,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "b65d836977544168934a5aa80e72a7b2",
+                    "md5sum" : "f6151447cafc9a1173f75dfff3bf8f27",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-v-sw",
                     "source" : "src/asmtest"
                 },
@@ -3758,7 +9420,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "3fc976679b7404343f553cca9d837ccb",
+                    "md5sum" : "ec3b44a0a44a789c4651b1b3e5b5e02e",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-v-xor",
                     "source" : "src/asmtest"
                 },
@@ -3768,7 +9430,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "54e3e45b8715933284af73de1dea33f0",
+                    "md5sum" : "c9289ed7423f2590071ba07c5015e6aa",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64ui-v-xori",
                     "source" : "src/asmtest"
                 },
@@ -3778,7 +9440,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "820dd93e9bd32aa0c6078e82b3a1d56e",
+                    "md5sum" : "745c77587bf1201c1c2a25ecd5125462",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64um-p-div",
                     "source" : "src/asmtest"
                 },
@@ -3788,7 +9450,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "2423002bc3997c1bb49db95ef5c2aae8",
+                    "md5sum" : "ef2ca0e9793033004cd80905e13986f6",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64um-p-divu",
                     "source" : "src/asmtest"
                 },
@@ -3798,7 +9460,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "87992ad64dd865331a4bcbf3fa14c014",
+                    "md5sum" : "c58e848c91b0e8ea97fe9158b6722752",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64um-p-divuw",
                     "source" : "src/asmtest"
                 },
@@ -3808,7 +9470,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "94cdea0f7388a1c756017ad892842066",
+                    "md5sum" : "ac5bc38bc08284b1e3f819e286c9cf99",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64um-p-divw",
                     "source" : "src/asmtest"
                 },
@@ -3818,7 +9480,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "56a0b94c8b01189a4ee89fa963fa8728",
+                    "md5sum" : "27cc408dbbed2a443e98016024e3909a",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64um-p-mul",
                     "source" : "src/asmtest"
                 },
@@ -3828,7 +9490,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "96b114196281da84401ea85fbe7374cd",
+                    "md5sum" : "906f11d9631bc68da7d63be3f0a94a4b",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64um-p-mulh",
                     "source" : "src/asmtest"
                 },
@@ -3838,7 +9500,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "c4e736755d41b88d38609d1e93c478b6",
+                    "md5sum" : "4cec0d061f8063155c42d73f5193f674",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64um-p-mulhsu",
                     "source" : "src/asmtest"
                 },
@@ -3848,7 +9510,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "69eb85950fc484e5d342de6b3e5bff1d",
+                    "md5sum" : "3f7f3516c3c0837a9a32bfa997ba6232",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64um-p-mulhu",
                     "source" : "src/asmtest"
                 },
@@ -3858,7 +9520,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "1e6b85556decd6f1fcce889f8d2013d3",
+                    "md5sum" : "1400234fa0976deab9ddeedbd2b88f91",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64um-p-mulw",
                     "source" : "src/asmtest"
                 },
@@ -3868,7 +9530,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "8c8ddfce7ca7feb2c454b882cdb7633a",
+                    "md5sum" : "c2a33a32389b6eb9726495b81a6fb53e",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64um-p-rem",
                     "source" : "src/asmtest"
                 },
@@ -3878,7 +9540,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "b8b793b7b178d986e36ff93e2b1e0f9c",
+                    "md5sum" : "21c84d13e557ae11d507a64848a56647",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64um-p-remu",
                     "source" : "src/asmtest"
                 },
@@ -3888,7 +9550,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "258ed5fc8d7cd8002fa3ec7288e63aaa",
+                    "md5sum" : "0a69facc0763ed3b910736862da4f33d",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64um-p-remuw",
                     "source" : "src/asmtest"
                 },
@@ -3898,7 +9560,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "926257e6eccf64456086994635101f0c",
+                    "md5sum" : "d0987b625eb7efac0d95becc8f256096",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64um-p-remw",
                     "source" : "src/asmtest"
                 },
@@ -3908,7 +9570,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "602ae8b873ba3e39b4b62300b66f59a2",
+                    "md5sum" : "940f9292c9e4022494bb99b773968408",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64um-ps-div",
                     "source" : "src/asmtest"
                 },
@@ -3918,7 +9580,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "8809b137e030244ca0f9ffc0d1989504",
+                    "md5sum" : "bec3e88361ef960556b1c5936893559c",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64um-ps-divu",
                     "source" : "src/asmtest"
                 },
@@ -3928,7 +9590,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "c294f1703a609b2ab91ef6b31e9fa1d8",
+                    "md5sum" : "073a96353d8684b6994780e67ad28dce",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64um-ps-divuw",
                     "source" : "src/asmtest"
                 },
@@ -3938,7 +9600,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "8c59d76fd7786c2b0bbd9f3c54794774",
+                    "md5sum" : "307f14076bc2b9c3d5c0ad237c4e9084",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64um-ps-divw",
                     "source" : "src/asmtest"
                 },
@@ -3948,7 +9610,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "f9d4ede3f8427efdd0c79c2c17938f3b",
+                    "md5sum" : "0ef900fe67fcd2c4e46728a52b5017a9",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64um-ps-mul",
                     "source" : "src/asmtest"
                 },
@@ -3958,7 +9620,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "34514d7c23c1ad2ce38746b79d398a24",
+                    "md5sum" : "3dadf4bb18b10b3ba26f6797366ae3c2",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64um-ps-mulh",
                     "source" : "src/asmtest"
                 },
@@ -3968,7 +9630,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "e7ff21e8c1ea8876d517145c25ab13d5",
+                    "md5sum" : "142f6430afb3694b5c3b7da293840adf",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64um-ps-mulhsu",
                     "source" : "src/asmtest"
                 },
@@ -3978,7 +9640,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "dc55005966c9c28062e8a79f83b65f96",
+                    "md5sum" : "04544c572325783041b478cfdc76f9ee",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64um-ps-mulhu",
                     "source" : "src/asmtest"
                 },
@@ -3988,7 +9650,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "ae60abbf79902a2027a9e4338e74cc6b",
+                    "md5sum" : "6681bfd609d84df20667711e831e2e30",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64um-ps-mulw",
                     "source" : "src/asmtest"
                 },
@@ -3998,7 +9660,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "c1736d9576801eb4bec8fa1685b44691",
+                    "md5sum" : "5fc5387f6028815e1a4bbe260b5f6ee8",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64um-ps-rem",
                     "source" : "src/asmtest"
                 },
@@ -4008,7 +9670,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "42d352b6738309f9068dd241f074370f",
+                    "md5sum" : "acc9db6837af7edaff47d328f76c5b39",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64um-ps-remu",
                     "source" : "src/asmtest"
                 },
@@ -4018,7 +9680,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "f314392cb6caea00338bb19ca720be12",
+                    "md5sum" : "67fabcfa4194a5b7201d18be00c96b87",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64um-ps-remuw",
                     "source" : "src/asmtest"
                 },
@@ -4028,7 +9690,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "951f8ff2e317fd8789cf84b8a23150a2",
+                    "md5sum" : "c7f2b55b89df76f7ced45b42ceb1b7fc",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64um-ps-remw",
                     "source" : "src/asmtest"
                 },
@@ -4038,7 +9700,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "3b5f9fed1d39c75ea32408e19bc4a0df",
+                    "md5sum" : "d2df0a689719ec928dc5b29a1962e2c9",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64um-v-div",
                     "source" : "src/asmtest"
                 },
@@ -4048,7 +9710,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "bd0825b6474751887b99d7a05df31fa8",
+                    "md5sum" : "d1c4ba036096ea1eada9d5fc01934aed",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64um-v-divu",
                     "source" : "src/asmtest"
                 },
@@ -4058,7 +9720,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "c8855c9a292eb86dee8e11ddcc88b843",
+                    "md5sum" : "a65e20d59f873b450389d17ae9203b8c",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64um-v-divuw",
                     "source" : "src/asmtest"
                 },
@@ -4068,7 +9730,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "6e33cb55a71ba378c739fb63cecf85a1",
+                    "md5sum" : "1fa1401c044dd6ca002c4f4e67de8adb",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64um-v-divw",
                     "source" : "src/asmtest"
                 },
@@ -4078,7 +9740,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "cbf41e207dfb09c352582d97f1cf5ddf",
+                    "md5sum" : "bb6f133204950f3626c24d12d7c123c9",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64um-v-mul",
                     "source" : "src/asmtest"
                 },
@@ -4088,7 +9750,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "387c221747ca8160b6f461060ea44640",
+                    "md5sum" : "2255bc9082e4a6eb8fd30fec448bf6ed",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64um-v-mulh",
                     "source" : "src/asmtest"
                 },
@@ -4098,7 +9760,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "09d283d8a482edee0bbaa04abaffe587",
+                    "md5sum" : "003510529c109400b387359cbfafc36e",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64um-v-mulhsu",
                     "source" : "src/asmtest"
                 },
@@ -4108,7 +9770,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "f21396ba8d1feba4225413fcdd93e859",
+                    "md5sum" : "ca8884d3de87089b5132393aceb3adf0",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64um-v-mulhu",
                     "source" : "src/asmtest"
                 },
@@ -4118,7 +9780,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "8b7409faa548e836aa8391544659b237",
+                    "md5sum" : "175e40ba2bbd3ae7b78859f35a85dce1",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64um-v-mulw",
                     "source" : "src/asmtest"
                 },
@@ -4128,7 +9790,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "0375cd5552dbfdfafe6272f34a4312bc",
+                    "md5sum" : "0ba9bca2446c6054f5d0b4b0dd2cb6a2",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64um-v-rem",
                     "source" : "src/asmtest"
                 },
@@ -4138,7 +9800,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "8d2301cca38b588f03206b9dd4d0e082",
+                    "md5sum" : "f958a0e1aec9ab89226c0a0321180575",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64um-v-remu",
                     "source" : "src/asmtest"
                 },
@@ -4148,7 +9810,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "241e4de12fd79207aac6f321773b041c",
+                    "md5sum" : "5ab3c765db49735bdd172e7ac4ef44d4",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64um-v-remuw",
                     "source" : "src/asmtest"
                 },
@@ -4158,7 +9820,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "aff1c28cdb84b9509547935c62aec435",
+                    "md5sum" : "d1e6d6c63788a880f0b784d11bce42a6",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64um-v-remw",
                     "source" : "src/asmtest"
                 },
@@ -4168,7 +9830,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "b4b6127cf0b70dc428e9dc84ff924675",
+                    "md5sum" : "d540d26baa5e3073335118e58b250230",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64uzfh-ps-fadd",
                     "source" : "src/asmtest"
                 },
@@ -4178,7 +9840,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "51987dc0a2e25c41ea7a60b3e1b6d3e1",
+                    "md5sum" : "c8d451e88aa848d958c39507ae872cbc",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64uzfh-ps-fclass",
                     "source" : "src/asmtest"
                 },
@@ -4188,7 +9850,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "38d202dfe077171e0dcfcd4f3a09e14d",
+                    "md5sum" : "042bf969b342db9b504dae00fe554a06",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64uzfh-ps-fcmp",
                     "source" : "src/asmtest"
                 },
@@ -4198,7 +9860,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "4e703e3534179c2db1173c7c67b2edb8",
+                    "md5sum" : "30116e862c92150da8866bac3ae8819c",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64uzfh-ps-fcvt",
                     "source" : "src/asmtest"
                 },
@@ -4208,7 +9870,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "195875e6a42e191681f0d0e0f7c4d5a2",
+                    "md5sum" : "fa4f1152e60084e77048a466bbf56b44",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64uzfh-ps-fcvt_w",
                     "source" : "src/asmtest"
                 },
@@ -4218,7 +9880,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "06c66b6a66480122699d3224f84e0abe",
+                    "md5sum" : "ea06c5e1d1cd3b92e66717f9eb797031",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64uzfh-ps-fdiv",
                     "source" : "src/asmtest"
                 },
@@ -4228,7 +9890,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "096e6454a25877b19de22054ecc08540",
+                    "md5sum" : "55f70c033e2e3de04572b3524b662421",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64uzfh-ps-fmadd",
                     "source" : "src/asmtest"
                 },
@@ -4238,7 +9900,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "3b392c9fb858199f6a701fd4b16feb0d",
+                    "md5sum" : "871e96c66f7542675f62586ac61c3703",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64uzfh-ps-fmin",
                     "source" : "src/asmtest"
                 },
@@ -4248,7 +9910,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "794f5106977c726639e4d0f6b93fa38c",
+                    "md5sum" : "14279387d3667c374ae069ef317637a8",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64uzfh-ps-ldst",
                     "source" : "src/asmtest"
                 },
@@ -4258,7 +9920,7 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "0d3bd78a75a3dded8d97be0965af1b90",
+                    "md5sum" : "9b3fb9e78b3d726c85f604a91fa8a987",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64uzfh-ps-move",
                     "source" : "src/asmtest"
                 },
@@ -4268,12 +9930,11 @@
                     "documentation" : "A RISCV binary used to test a specific RISCV instruction.",
                     "architecture" : "RISCV",
                     "is_zipped" : false,
-                    "md5sum" : "8b6f3dbfa31f3e679417ba7b35ee8c2f",
+                    "md5sum" : "30a784c7be5dd05baf7da4d34011f52a",
                     "url" : "{url_base}/test-progs/asmtest/bin/rv64uzfh-ps-recoding",
                     "source" : "src/asmtest"
                 }
-			]
-		}
-	]
+          ]
+        }
+    ]
 }
-


### PR DESCRIPTION
For reasons that are not presently understood, the resources.json file hosted at http://resources.gem5.org/resource.json is out-of-sync with that found in the root of the https://github.com/gem5/gem5-resources repository. The resources.json file hosted on the website appears to be missing entires.

This is known to produce errors, such as that in gem5/gem5#127.

This patch syncs the resources in gem5/gem5-resources to that hosted on the website. This should fix these errors.