### PR TITLE
README changes

### DIFF
--- a/components/resourceMetadata.js
+++ b/components/resourceMetadata.js
@@ -82,21 +82,17 @@ export default function MetaData({ resource, className, metaFields, showMetadata
                             }) : 'Unknown'}
                         </h4>
                     </Row>
-                    <Row className="border-bottom">
-                        <p className="text-muted main-text-regular">Description</p>
-                        <p className="main-text-regular">
-                            {resource.description ?? 'This is a description of the resource.'}
-                        </p>
-                        {
-                            resource.source_url ?
+                    { resource.source_url ?
+                        <Row className="border-bottom">
+                            <p className="text-muted main-text-regular">Source</p>
                                 <Link
                                     href={resource.source_url}
                                     className="main-text-regular"
                                 >
                                     Repository (GitHub)
-                                </Link> : null
-                        }
-                    </Row>
+                                </Link>
+                        </Row> : null
+                    }
                     <Row className="border-bottom">
                         <p className="text-muted main-text-regular">License</p>
                         <p className="main-text-regular">

--- a/components/resourceTab.js
+++ b/components/resourceTab.js
@@ -130,33 +130,16 @@ export default function ResourceTab({ resource, requiredTabs, additionalInfoTabs
         className="mb-2 main-text-regular"
       >
         <Tab eventKey="readme" title="Readme">
-        <ReactMarkdown
-                className="markdown-body mt-3"
-                rehypePlugins={[
-                    [rehypeHighlight, { ignoreMissing: true }],
-                    rehypeRaw,
-                    rehypeSlug,
-                ]}
-                remarkPlugins={[remarkGfm, remarkToc, remarkFrontmatter]}
-                components={{
-                    // pre: ({ node, ...props }) => (
-                    //     <CopyIcon>
-                    //         <pre {...props}>{props.children}</pre>
-                    //     </CopyIcon>
-                    // ),
-                    // // add url to image
-                    // img: ({ node, ...props }) => (
-                    //     <Image
-                    //         {...props}
-                    //         src={`${github_url
-                    //             .replace("github.com", "raw.githubusercontent.com")
-                    //             .replace("tree/", "")}/${props.src}`}
-                    //         alt="Changelog"
-                    //     />
-                    // ),
-                }}
-          >
-            {resource.description ?? 'This is a description of the resource.'}
+          <ReactMarkdown
+                    className="markdown-body mt-3"
+                    rehypePlugins={[
+                        [rehypeHighlight, { ignoreMissing: true }],
+                        rehypeRaw,
+                        rehypeSlug,
+                    ]}
+                    remarkPlugins={[remarkGfm, remarkToc, remarkFrontmatter]}
+              >
+                {resource.description ?? 'This is a description of the resource.'}
           </ReactMarkdown>
         </Tab>
         <Tab eventKey="changelog" title="Changelog">

--- a/components/resourceTab.js
+++ b/components/resourceTab.js
@@ -9,6 +9,13 @@ import ChangelogTab from "./tabs/changelogTab";
 import UsageTab from "./tabs/usageTab";
 import ExampleTab from "./tabs/exampleTab";
 import RawTab from "./tabs/rawTab";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import remarkToc from "remark-toc";
+import rehypeHighlight from "rehype-highlight";
+import rehypeSlug from "rehype-slug";
+import rehypeRaw from "rehype-raw";
+import remarkFrontmatter from "remark-frontmatter";
 
 export function createTab(tab) {
   if (!"content" in tab) return null;
@@ -123,7 +130,34 @@ export default function ResourceTab({ resource, requiredTabs, additionalInfoTabs
         className="mb-2 main-text-regular"
       >
         <Tab eventKey="readme" title="Readme">
-          <ReadmeTab github_url={resource.source_url} />
+        <ReactMarkdown
+                className="markdown-body mt-3"
+                rehypePlugins={[
+                    [rehypeHighlight, { ignoreMissing: true }],
+                    rehypeRaw,
+                    rehypeSlug,
+                ]}
+                remarkPlugins={[remarkGfm, remarkToc, remarkFrontmatter]}
+                components={{
+                    // pre: ({ node, ...props }) => (
+                    //     <CopyIcon>
+                    //         <pre {...props}>{props.children}</pre>
+                    //     </CopyIcon>
+                    // ),
+                    // // add url to image
+                    // img: ({ node, ...props }) => (
+                    //     <Image
+                    //         {...props}
+                    //         src={`${github_url
+                    //             .replace("github.com", "raw.githubusercontent.com")
+                    //             .replace("tree/", "")}/${props.src}`}
+                    //         alt="Changelog"
+                    //     />
+                    // ),
+                }}
+          >
+            {resource.description ?? 'This is a description of the resource.'}
+          </ReactMarkdown>
         </Tab>
         <Tab eventKey="changelog" title="Changelog">
           <ChangelogTab github_url={resource.source_url} />

--- a/cypress/e2e/resourcePage.cy.js
+++ b/cypress/e2e/resourcePage.cy.js
@@ -65,8 +65,7 @@ describe('resource Page', () => {
     })
 
     it('checks if resource metadata is correct', () => {
-        cy.get('.metadata_info__8irfG > :nth-child(3) > :nth-child(2)').should('have.text', resource.description)
-        cy.get('.metadata_info__8irfG > :nth-child(4) > :nth-child(2)').should('have.text', resource.license === "" ? "Unknown" : resource.license)
+        cy.get('.metadata_info__8irfG > :nth-child(2) > :nth-child(2)').should('have.text', resource.license === "" ? "Unknown" : resource.license)
     })
 
     it('checks if tabs are correct', () => {


### PR DESCRIPTION
This PR makes a few changes to the way information is displayed on the gem5 Resources website.

1. "Description" tab in the metadata is replaced with "Source" and only the Source URL of the Resource is shown on this tab if it exists. If it does not, this tab does not render.
2. The README tab now only shows the "description" field of the Resource.